### PR TITLE
feat: handle non-svelte source files

### DIFF
--- a/lib/cli/build.js
+++ b/lib/cli/build.js
@@ -24,6 +24,7 @@ export async function build(_cayo) {
       ...config.build,
       emptyOutDir: true,
       rollupOptions: {
+        ...config.vite.rollupOptions,
         input: {
           ...inputs,
         },

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -12,7 +12,6 @@ import {
 
 import { loadConfig } from '../core/config.js';
 import * as compile from '../core/compile/index.js';
-import { getDeps } from '../core/bundle.js';
 import { logger } from '../core/logger.js';
 import { debugStats } from '../core/utils.js';
 
@@ -98,8 +97,10 @@ async function run(command) {
       components: new Map(),
       stats: {
         dependencies: { 
-          pages: { },
-          components: { },
+          pages: {},
+          components: {},
+          entries: {},
+          assets: {},
         },
         cayoComponents: { },
         compiled: {

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -13,7 +13,7 @@ import {
 
 import { loadConfig } from '../core/config.js';
 import * as compile from '../core/compile/index.js';
-import { logger } from '../core/logger.js';
+import logger from '../core/logger.js';
 import { debugStats } from '../core/utils.js';
 
 import { dev } from './dev.js';

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -7,6 +7,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 import { 
   writePageFiles,
+  writeEntryFile,
   cleanCayoPath,
 } from '../core/files.js';
 
@@ -132,6 +133,7 @@ async function run(command) {
 
       for (const [, page] of _cayo.pages) {
         await writePageFiles(page, _cayo);
+        await writeEntryFile(page, _cayo);
       } 
 
     } catch (err) {

--- a/lib/cli/serve.js
+++ b/lib/cli/serve.js
@@ -9,9 +9,7 @@ export async function serve(config) {
     mode: config.mode,
     base: config.base,
     configFile: false,
-  } 
-
-  // const mergedConfig = merge(config.viteConfig, serveConfig);
+  }
   
   const server = await createServer({
     ...merge(config.vite, serveConfig),

--- a/lib/cli/watch.js
+++ b/lib/cli/watch.js
@@ -3,8 +3,8 @@ import chokidar from 'chokidar';
 import chalk from 'chalk';
 import { logger } from '../core/logger.js';
 import * as compile from '../core/compile/index.js';
-import { findDependentCayos, findDependentPages } from '../core/dependencies.js';
-import { writePageFiles } from '../core/files.js';
+import { findDependentPages } from '../core/dependencies.js';
+import { writeEntryFile, writePageFiles } from '../core/files.js';
 import { debugStats } from '../core/utils.js';
 
 export function watch(_cayo) {
@@ -54,9 +54,9 @@ export function watch(_cayo) {
         logChange('template');
         await handleTemplate(_cayo);
 
+        // Handle Pages
       } else if (filepath.startsWith(config.pages)) {
         logChange('page', filepath);
-        // Handle Pages
         await handlePage(filepath, _cayo);
       
       // Handle Cayos
@@ -68,9 +68,11 @@ export function watch(_cayo) {
       } else if (filepath.startsWith(config.components)) {
         logChange('component', filepath);
         await handleComponent(filepath, _cayo);
-      } else {
-        // TODO: what happens?
-        // prerenderPages(config);
+      }
+    // Handle everything else
+    } else {
+      if (_cayo.stats.dependencies.entries[filepath]) {
+        await handleEntry(filepath, _cayo);
       }
     }
   });
@@ -101,6 +103,14 @@ async function handleComponent(filepath, _cayo) {
   const dependentPages = findDependentPages(filepath, _cayo);
   for (const page of dependentPages) {
     await handlePage(page, _cayo);
+  }
+}
+
+async function handleEntry(filepath, _cayo) {
+  for (const [, page] of _cayo.pages) {
+    if (filepath === page.result.entry.path) {
+      writeEntryFile(page, _cayo);
+    }
   }
 }
 

--- a/lib/cli/watch.js
+++ b/lib/cli/watch.js
@@ -4,7 +4,7 @@ import chalk from 'chalk';
 import { logger } from '../core/logger.js';
 import * as compile from '../core/compile/index.js';
 import { findDependentPages } from '../core/dependencies.js';
-import { writeEntryFile, writePageFiles } from '../core/files.js';
+import { writePageFiles, writeEntryFile } from '../core/files.js';
 import { debugStats } from '../core/utils.js';
 
 export function watch(_cayo) {
@@ -111,7 +111,7 @@ async function handleComponent(filepath, _cayo) {
 async function handleEntry(filepath, _cayo) {
   for (const [, page] of _cayo.pages) {
     if (filepath === page.result.entry.path) {
-      writeEntryFile(page, _cayo);
+      await writeEntryFile(page, _cayo);
     }
   }
 }
@@ -135,7 +135,9 @@ async function handlePage(filepath, _cayo) {
       debugStats(_cayo);
     }
 
-    writePageFiles(page, _cayo);
+    await writePageFiles(page, _cayo);
+    await writeEntryFile(page, _cayo);
+
   } catch (err) {
     console.error(err);
     logger.error(err);

--- a/lib/cli/watch.js
+++ b/lib/cli/watch.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import chokidar from 'chokidar';
 import chalk from 'chalk';
-import { logger } from '../core/logger.js';
+import logger from '../core/logger.js';
 import * as compile from '../core/compile/index.js';
 import { findDependentPages } from '../core/dependencies.js';
 import { writePageFiles, writeEntryFile } from '../core/files.js';
@@ -81,23 +81,14 @@ export function watch(_cayo) {
 }
 
 async function handleTemplate(_cayo) {
-  try {
-    await compile.template(_cayo);
-    for (const [key] of _cayo.pages) {
-      await handlePage(key, _cayo);
-    }
-  } catch (err) {
-    logger.error(err);
+  await compile.template(_cayo);
+  for (const [key] of _cayo.pages) {
+    await handlePage(key, _cayo);
   }
 }
 
 async function handleCayo(filepath, _cayo) {
-  try {
-    // await compile.cayos(null, _cayo);
-    await handleComponent(filepath, _cayo);
-  } catch (err) {
-    logger.error(err);
-  }
+  await handleComponent(filepath, _cayo);
 }
 
 async function handleComponent(filepath, _cayo) {
@@ -121,14 +112,7 @@ async function handlePage(filepath, _cayo) {
   const page = (await compile.pages([filepath], _cayo))[0];
   pages.set(filepath, page);
   await page.render(_cayo, { load: true });
-  
-  // Recompile any cayos rendered by this page
-  // const cayos = [..._cayo.stats.cayoComponents].filter(cayo => {
-  //   if (cayo.pages.has(filepath)) return cayo;
-  // });
-  // await compile.cayos(cayos, _cayo);
 
-  // for debugging
   if (_cayo.config.debug) {
     debugStats(_cayo);
   }

--- a/lib/cli/watch.js
+++ b/lib/cli/watch.js
@@ -3,7 +3,7 @@ import chokidar from 'chokidar';
 import chalk from 'chalk';
 import { logger } from '../core/logger.js';
 import * as compile from '../core/compile/index.js';
-import { findDependentCayos, findDependentPages } from '../core/compile/dependencies.js';
+import { findDependentCayos, findDependentPages } from '../core/dependencies.js';
 import { writePageFiles } from '../core/files.js';
 import { debugStats } from '../core/utils.js';
 

--- a/lib/cli/watch.js
+++ b/lib/cli/watch.js
@@ -76,9 +76,8 @@ export function watch(_cayo) {
         await handleEntry(filepath, _cayo);
       }
       // TODO: check if file is a dep of an entry
-    }
+    }  
   });
-  // watcher.close();
 }
 
 async function handleTemplate(_cayo) {
@@ -119,27 +118,21 @@ async function handleEntry(filepath, _cayo) {
 async function handlePage(filepath, _cayo) {
   const { pages } = _cayo;
 
-  try {
-    const page = (await compile.pages([filepath], _cayo))[0];
-    pages.set(filepath, page);
-    await page.render(_cayo, { load: true });
-    
-    // Recompile any cayos rendered by this page
-    // const cayos = [..._cayo.stats.cayoComponents].filter(cayo => {
-    //   if (cayo.pages.has(filepath)) return cayo;
-    // });
-    // await compile.cayos(cayos, _cayo);
+  const page = (await compile.pages([filepath], _cayo))[0];
+  pages.set(filepath, page);
+  await page.render(_cayo, { load: true });
+  
+  // Recompile any cayos rendered by this page
+  // const cayos = [..._cayo.stats.cayoComponents].filter(cayo => {
+  //   if (cayo.pages.has(filepath)) return cayo;
+  // });
+  // await compile.cayos(cayos, _cayo);
 
-    // for debugging
-    if (_cayo.config.debug) {
-      debugStats(_cayo);
-    }
-
-    await writePageFiles(page, _cayo);
-    await writeEntryFile(page, _cayo);
-
-  } catch (err) {
-    console.error(err);
-    logger.error(err);
+  // for debugging
+  if (_cayo.config.debug) {
+    debugStats(_cayo);
   }
+
+  await writePageFiles(page, _cayo);
+  await writeEntryFile(page, _cayo);
 }

--- a/lib/cli/watch.js
+++ b/lib/cli/watch.js
@@ -72,8 +72,10 @@ export function watch(_cayo) {
     // Handle everything else
     } else {
       if (_cayo.stats.dependencies.entries[filepath]) {
+        logChange('entry', filepath);
         await handleEntry(filepath, _cayo);
       }
+      // TODO: check if file is a dep of an entry
     }
   });
   // watcher.close();

--- a/lib/components/cayo-warnings.js
+++ b/lib/components/cayo-warnings.js
@@ -30,7 +30,7 @@ function checkBadProps(warnings, src, keys) {
     warnings.badProps = {
       title: `Bad props`,
       src,
-      message: `Unserializable props found: ${propsStr}. Cayo component props must be serializable in order to be passed during hydration.`,
+      message: `Unserializable props found: ${propsStr}. Cayo component props must be serializable in order to be used for hydration.`,
       log: `Unserializable instance props found: ${propsStr}.`,
     }
   }

--- a/lib/core/bundle.js
+++ b/lib/core/bundle.js
@@ -5,8 +5,6 @@ import css from 'rollup-plugin-import-css';
 import json from '@rollup/plugin-json';
 // import cayoPreprocess from './preprocess/index.js';
 
-// TODO: consider: should some of this rollup plugin stuff be config based and not default?
-
 function inputOptions(input) {
   return { 
     input, 
@@ -18,6 +16,10 @@ function inputOptions(input) {
 
 function defaultRollupPlugins() {
   return [css(), json()];
+}
+
+function userRollupPlugins(config) {
+  return config.vite.rollupOptions.plugins;
 }
 
 export async function getDeps(input, config) {
@@ -37,16 +39,16 @@ export async function getDeps(input, config) {
         ],
       }), 
       ...defaultRollupPlugins(),
-      ...config.rollup.plugins,
+      ...userRollupPlugins(config),
     ]
   }
   try {
-    // create a bundle
+    // Create a bundle
     bundle = await rollup(options);
     if (bundle) {
       await bundle.close();
     }
-    // an array of file names this bundle depends on
+    // An array of file names this bundle depends on
     return bundle.watchFiles.filter(dep => (dep !== input));
 
   } catch (err) {
@@ -66,7 +68,6 @@ export async function getDeps(input, config) {
   
 }
 
-// TODO: should probably support rollup plugins passed via config
 export async function build(input, config, type = 'page') {
 
   const ssr = (type === 'page' || type === 'template');
@@ -103,7 +104,7 @@ export async function build(input, config, type = 'page') {
         extensions: config.svelte.extensions,
       }), 
       ...defaultRollupPlugins(),
-      ...config.rollup.plugins,
+      ...userRollupPlugins(config),
     ]
   }
 

--- a/lib/core/bundle.js
+++ b/lib/core/bundle.js
@@ -3,8 +3,7 @@ import { rollup } from 'rollup';
 import svelte from 'rollup-plugin-svelte';
 import css from 'rollup-plugin-import-css';
 import json from '@rollup/plugin-json';
-import sveltePreprocess from 'svelte-preprocess';
-import cayoPreprocess from './preprocess/index.js';
+// import cayoPreprocess from './preprocess/index.js';
 
 // TODO: consider: should some of this rollup plugin stuff be config based and not default?
 
@@ -17,18 +16,27 @@ function inputOptions(input) {
   };
 }
 
+function defaultRollupPlugins() {
+  return [css(), json()];
+}
+
 export async function getDeps(input, config) {
   let bundle;
+  // User-defined preprocessors
+  let preprocessors = config.svelte.preprocess.length > 0 
+    ? config.svelte.preprocess 
+    : [config.svelte.preprocess];
+
   const options = { 
     ...inputOptions(input),
     plugins: [
       svelte({
-        // NOTE: pretty sure this could break pretty easily if user-defined preprocess stuff isn't passed down
-        // maybe need to separetely support svelte-specific config as a different key in the cayo config
-        preprocess: sveltePreprocess(),
+        preprocess: [
+          // cayoPreprocess(config),
+          ...preprocessors,
+        ],
       }), 
-      css(),
-      json(),
+      ...defaultRollupPlugins(),
       ...config.rollup.plugins,
     ]
   }
@@ -64,7 +72,7 @@ export async function build(input, config, type = 'page') {
   const ssr = (type === 'page' || type === 'template');
   const requiredCompilerOptions = {
     generate: ssr ? 'ssr' : 'dom', 
-    hydratable: ssr ? false : true, // this is default, may need to be changed just fo Cayo components
+    hydratable: ssr ? false : true, 
   }
 
   let bundle;
@@ -73,7 +81,7 @@ export async function build(input, config, type = 'page') {
     css: { code: '' },
     dependencies: [],
   };
-
+  // User-defined preprocessors
   let preprocessors = config.svelte.preprocess.length > 0 
     ? config.svelte.preprocess 
     : [config.svelte.preprocess];
@@ -83,9 +91,7 @@ export async function build(input, config, type = 'page') {
     plugins: [
       svelte({
         preprocess: [
-          // Internal cayo preprocessors
-          cayoPreprocess(config),
-          // User-defined preprocessors
+          // cayoPreprocess(config),
           ...preprocessors,
         ],
         compilerOptions: {
@@ -96,8 +102,7 @@ export async function build(input, config, type = 'page') {
         },
         extensions: config.svelte.extensions,
       }), 
-      css(),
-      json(),
+      ...defaultRollupPlugins(),
       ...config.rollup.plugins,
     ]
   }

--- a/lib/core/bundle.js
+++ b/lib/core/bundle.js
@@ -1,28 +1,23 @@
+import fs from 'fs-extra';
 import { rollup } from 'rollup';
 import svelte from 'rollup-plugin-svelte';
-import sveltePreprocess from 'svelte-preprocess';
-import { logger } from './logger.js';
-import cayoPreprocess from './preprocess/index.js';
-import chalk from 'chalk';
-// TODO: consider: should some of this rollup plugin stuff be config based and not default?
-import resolve from '@rollup/plugin-node-resolve';
-// import ignoreImport from 'rollup-plugin-ignore-import';
 import css from 'rollup-plugin-import-css';
 import json from '@rollup/plugin-json';
+import sveltePreprocess from 'svelte-preprocess';
+import cayoPreprocess from './preprocess/index.js';
 
+// TODO: consider: should some of this rollup plugin stuff be config based and not default?
 
 function inputOptions(input) {
   return { 
     input, 
     onwarn: function ( message ) {
       if ( /external dependency/.test( message ) ) return;
-      // console.error( message );
     },
   };
 }
 
 export async function getDeps(input, config) {
-  // console.log('hold up bruther', input);
   let bundle;
   const options = { 
     ...inputOptions(input),
@@ -34,27 +29,33 @@ export async function getDeps(input, config) {
       }), 
       css(),
       json(),
-      // resolve()
+      ...config.rollup.plugins,
     ]
   }
-  // console.log('config', options);
   try {
     // create a bundle
     bundle = await rollup(options);
+    if (bundle) {
+      await bundle.close();
+    }
     // an array of file names this bundle depends on
     return bundle.watchFiles.filter(dep => (dep !== input));
 
-  } catch (error) {
-    // do some error reporting
-    const spacer = '       '; // aligns with '[cayo] <message>' messages
-    logger.error(`Error: Parsing dependencies in '${input.replace(config.src, 'src/')}'`);
-    logger.error(`${spacer}Rollup: ${error.code}\n${spacer}Rollup: ${error.message}`, { prefix: false });
-    // console.error(error);
+  } catch (err) {
+    let errorMessage = `Parsing dependencies of '${input.replace(config.src, 'src/')}'`;
+    if (!fs.pathExistsSync(input)) {
+      errorMessage += `\n> File does not exist: '${input}'.`;
+    } else {
+      errorMessage += `\n> Rollup Error: ${err.code}`; 
+      if (err.code === 'PLUGIN_ERROR') {
+        errorMessage += `\n> ${err.plugin} (Error code: ${err.pluginCode})`;  
+      }
+      errorMessage += `\n> Trace: ${err.stack}`;
+    }
+    
+    throw new Error(errorMessage, { cause: err });
   }
-  if (bundle) {
-    // closes the bundle
-    await bundle.close();
-  }
+  
 }
 
 // TODO: should probably support rollup plugins passed via config
@@ -114,18 +115,18 @@ export async function build(input, config, type = 'page') {
 
     return output;
 
-  } catch (error) {
+  } catch (err) {
     let relativeFilePath = input.replace(config[`${type}s`], '');
     let errorMessage = `Could not compile ${type}: '${relativeFilePath}'`;
-    errorMessage += `\n> Rollup Error: ${error.code}`; 
-    if (error.code === 'PLUGIN_ERROR') {
-      errorMessage += `\n> ${error.plugin} (Error code: ${error.pluginCode})`;  
+    errorMessage += `\n> Rollup Error: ${err.code}`; 
+    if (err.code === 'PLUGIN_ERROR') {
+      errorMessage += `\n> ${err.plugin} (Error code: ${err.pluginCode})`;  
     }
     errorMessage += `\n\n> Source: ${input}`;
-    errorMessage += `\n${error.frame}`
-    errorMessage += `\n> ${error.stack}`;
+    errorMessage += `\n${err.frame}`
+    errorMessage += `\n> ${err.stack}`;
 
-    throw new Error(errorMessage + error.message);
+    throw new Error(errorMessage, { cause: err });
   }
 }
 

--- a/lib/core/codegen.js
+++ b/lib/core/codegen.js
@@ -12,6 +12,7 @@ function getProps(cayoElement) {
   );
 }
 
+// Generate the Cayo Runtime which is unique per page to render the cayos on the page
 export function generateCayoRuntime(components, fileName, _cayo) {
   const { config, __VERSION__ } = _cayo;
   let code = '';
@@ -80,4 +81,9 @@ export function generateComponentInstance(cayoId, componentName) {
   });
 `
   );
+}
+
+// Generate the code to import the the generated Cayo Runtime file
+export function generateCayoRuntimeImport() {
+  return `import { default as renderCayos } from './cayo-runtime.js';\n`
 }

--- a/lib/core/codegen.js
+++ b/lib/core/codegen.js
@@ -1,4 +1,6 @@
 import path from 'path';
+import chalk from 'chalk';
+import logger from './logger.js';
 
 // Generate runtime helper that finds and parses a component instance's prop data
 export function generateGetProps() {
@@ -86,4 +88,75 @@ export function generateComponentInstance(cayoId, componentName) {
 // Generate the code to import the the generated Cayo Runtime file
 export function generateCayoRuntimeImport() {
   return `import { default as renderCayos } from './cayo-runtime.js';\n`
+}
+
+// TODO: add links to relevant docs
+// Generate console warnings that need to show in the browser
+export function generateRuntimeIssuesScript(runtime, issues, type) {
+  const { config, document, page } = runtime;
+  const script = document.createElement('script');
+
+  // Formattign and label stuff
+  let prefix = 'Warning';
+  let f_log = (str) => str;
+  let f_prefix = prefix
+  let consoleType = 'log';
+  if (type === 'warning') {
+    prefix = 'Warning';
+    f_log = chalk.yellow;
+    f_prefix = chalk.yellow.bold(prefix);
+    consoleType = 'warn';
+  } else if (type === 'error') {
+    prefix = 'Error';
+    f_log = chalk.redBright;
+    f_prefix = chalk.redBright.bold(prefix);
+    consoleType = 'error';
+  }
+  
+  const { 
+    cayos: cayoIssues, 
+    page: pageIssues,
+  } = issues;
+
+  script.innerHTML = `/* ${prefix}s for this page. See issues in console. */\n`;
+
+  // Handle issues derived during initial compilation of the cayo instance
+  if (Object.keys(cayoIssues).length > 0) {
+    for (const cayoId in cayoIssues) {
+      let message = `Cayo ${prefix}: Cayo '${cayoId}' has runtime issues.\n\n`;
+      for (const key in cayoIssues[cayoId]) {
+        const issue = cayoIssues[cayoId][key];
+        message += `${issue.title}: ${issue.message}\n\n`;
+        if (cayoId !== 'undefined') {
+          message += `Hint: review instances of <Cayo src="${issue.src}"> intended to be rendered on page '${page.sourcePath.replace(config.pages, '')}'\n`;
+        } else {
+          message += `Hint: review instances of <Cayo src={<undefined>}> or <Cayo> without a src prop intended to be rendered on page '${page.sourcePath.replace(config.pages, '')}'\n`;
+        }
+        if (issue.log) {
+          logger.log.info(
+            `${f_log(`${f_prefix}: ${issue.log}`)} ${chalk.dim(`${page.name}`)}`, 
+            { timestamp: true, clear: false, }
+          );
+        }
+      }
+      script.innerHTML += `console.${consoleType}(\`${message}\`);\n`;
+    }
+  }
+  // Handle issues derived from parsing the rendered HTML page
+  if (Object.keys(pageIssues).length > 0) {
+    for (const key in pageIssues) {
+      const issue = pageIssues[key];
+      let message = `${prefix}: page '${page.name}' has runtime issues.\n\n`;
+      message += `${issue.title}: ${issue.message}\n\n`;
+      script.innerHTML += `console.${consoleType}(\`${message}\`);\n`;
+      if (issue.log) {
+        logger.log.info(
+          `${f_log(`${f_prefix}: ${issue.log}`)} ${chalk.dim(`${page.name}`)}`, 
+          { timestamp: true, clear: false, }
+        );
+      }
+    }
+  }
+
+  return script;
 }

--- a/lib/core/compile/cayos.js
+++ b/lib/core/compile/cayos.js
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 
-import { handleDependencies } from './dependencies.js';
+import { handleDependencies } from '../dependencies.js';
 import { Component } from '../component.js';
 import { build } from '../bundle.js';
 import { generateCayoComponentId } from '../utils.js';

--- a/lib/core/compile/pages.js
+++ b/lib/core/compile/pages.js
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import fg from 'fast-glob';
 import path from 'path';
 
-import { handleDependencies } from './dependencies.js';
+import { handleDependencies } from '../dependencies.js';
 import { Page } from '../page.js';
 import { build } from '../bundle.js';
 import { logger } from '../logger.js';

--- a/lib/core/compile/pages.js
+++ b/lib/core/compile/pages.js
@@ -5,7 +5,7 @@ import path from 'path';
 import { handleDependencies } from '../dependencies.js';
 import { Page } from '../page.js';
 import { build } from '../bundle.js';
-import { logger } from '../logger.js';
+import logger from '../logger.js';
 
 export async function compilePages(pageModulePaths, _cayo) {
   const compiledPages = [];

--- a/lib/core/config.js
+++ b/lib/core/config.js
@@ -48,15 +48,18 @@ export async function validateConfig(userConfig) {
       })
       .optional()
       .default({}),
+    // Note: explicitly only supports these svelte config options
     svelte: z.object({
       preprocess: z.any().default([]),
       compilerOptions: z.any().default({}),
       extensions: z.string().array().default(['.svelte']),
     }).default({}),
-    vite: z.any({}),
-    rollup: z.object({
-      plugins: z.any().default([]),
-    }).default({}),
+    // Note: allows all vite config options
+    vite: z.any({}).default({
+      rollupOptions: {
+        plugins: [],
+      },
+    }),
     cayoPath: z
       .string()
       .default('.cayo/'),

--- a/lib/core/dependencies.js
+++ b/lib/core/dependencies.js
@@ -138,3 +138,31 @@ export function findDependentCayos(pageDependency, _cayo) {
 
   return cayos;
 }
+
+export async function getEntryDependencies(entry, page, _cayo) {
+  const { config } = _cayo;
+  let imports = precinct(entry.code, { type: 'es6' });
+  // Filter out public path ('/') and node_modules ('<package>')
+  let localDeps = imports.filter(d => d.startsWith('../') || d.startsWith('./'));
+  let absoluteDeps = localDeps.map(d => path.resolve(path.dirname(entry.path), d));
+  let srcRelativeLocalDeps = localDeps.map((d, i) => {
+    let pageCayoPath = path.resolve(config.cayoPath, page.url === '/' ? './' : page.url);
+    return path.relative(pageCayoPath, absoluteDeps[i]);
+  });
+  // let nodeModules = imports
+  //   .filter(d => !d.startsWith('../') && !d.startsWith('./') && !d.startsWith('/'))
+  //   .map(d => path.relative(config.cayoPath, `${config.projectRoot}/node_modules/${d}`));
+  
+  entry.dependencies = [];
+  for (let i = 0; i < localDeps.length; i++) {
+    entry.dependencies.push([localDeps[i], srcRelativeLocalDeps[i]]);
+  }
+
+
+  const depender = { 
+    type: 'entry', 
+    path: entry.path, 
+    dependencies: absoluteDeps, 
+  }
+  await handleDependencies(depender, _cayo);
+}

--- a/lib/core/dependencies.js
+++ b/lib/core/dependencies.js
@@ -4,6 +4,7 @@ import { walk } from 'svelte/compiler';
 import path from 'path';
 import { hash } from './utils.js';
 import { getDeps } from './bundle.js';
+import precinct from 'precinct';
 
 /**
  * Adds dependencies to the dependency tree
@@ -44,7 +45,6 @@ function addDependencies(depender, dependencies) {
       break;
   }
 
-  console.log('type', type);
   dependencies[type][depender.path] = new Set([...branch]);
 }
 
@@ -79,7 +79,7 @@ export async function handleDependencies(depender, _cayo) {
     }
 
     if (!stats.compiled.paths.has(dependency)) {
-      const deps = (await getDeps(dependency, config))
+      const deps = (await getDeps(dependency, config));
       // Recursively handle nested dependencies
       await handleDependencies({ 
         type,

--- a/lib/core/dependencies.js
+++ b/lib/core/dependencies.js
@@ -2,8 +2,8 @@
 // import { promises as fs } from 'fs';
 import { walk } from 'svelte/compiler';
 import path from 'path';
-import { hash } from '../utils.js';
-import { getDeps } from '../bundle.js';
+import { hash } from './utils.js';
+import { getDeps } from './bundle.js';
 
 /**
  * Adds dependencies to the dependency tree
@@ -33,18 +33,18 @@ function addDependencies(depender, dependencies) {
       type = 'pages';
       break;
     case 'component':
-    default:
       type = 'components';
-      if (dependencies.components[depender.path]) {
-        for (const component of dependencies.components[depender.path]) {
-          if (depender.path === component) {
-            branch = [...branch, component];
-          }
-        }
-      }
+      break;
+    case 'entry':
+      type = 'entries';
+      break;
+    case 'asset':
+    default:
+      type = 'assets';
       break;
   }
 
+  console.log('type', type);
   dependencies[type][depender.path] = new Set([...branch]);
 }
 
@@ -68,17 +68,24 @@ export async function handleDependencies(depender, _cayo) {
 
   // Iterate over the dependency tree
   for (const dependency of depender.dependencies) {
+    let type;
     if (dependency.endsWith('.svelte')) {
-      // Check if each dependency in the tree has been compiled
-      if (!stats.compiled.paths.has(dependency)) {
-        // It hasn't been compiled yet, so compile it and handle it's dependencies
-        const deps = (await getDeps(dependency, config))
-        // Recursively handle nested dependencies
-        await handleDependencies({ 
-          path: dependency, 
-          dependencies: deps 
-        }, _cayo, config);
-      }
+      type = 'component';
+    } else if (dependency.endsWith('.js')) {
+      type = 'asset';
+    } else {
+      // Return early if it's not a file we can handle
+      return branch;
+    }
+
+    if (!stats.compiled.paths.has(dependency)) {
+      const deps = (await getDeps(dependency, config))
+      // Recursively handle nested dependencies
+      await handleDependencies({ 
+        type,
+        path: dependency, 
+        dependencies: deps 
+      }, _cayo, config);
     }
   }
 

--- a/lib/core/dependencies.js
+++ b/lib/core/dependencies.js
@@ -5,6 +5,7 @@ import path from 'path';
 import { hash } from './utils.js';
 import { getDeps } from './bundle.js';
 import precinct from 'precinct';
+import fs from 'fs-extra';
 
 /**
  * Adds dependencies to the dependency tree
@@ -81,11 +82,13 @@ export async function handleDependencies(depender, _cayo) {
     if (!stats.compiled.paths.has(dependency)) {
       const deps = (await getDeps(dependency, config));
       // Recursively handle nested dependencies
-      await handleDependencies({ 
-        type,
-        path: dependency, 
-        dependencies: deps 
-      }, _cayo, config);
+      if (deps) {
+        await handleDependencies({ 
+          type,
+          path: dependency, 
+          dependencies: deps 
+        }, _cayo, config);
+      }
     }
   }
 
@@ -149,20 +152,22 @@ export async function getEntryDependencies(entry, page, _cayo) {
     let pageCayoPath = path.resolve(config.cayoPath, page.url === '/' ? './' : page.url);
     return path.relative(pageCayoPath, absoluteDeps[i]);
   });
-  // let nodeModules = imports
-  //   .filter(d => !d.startsWith('../') && !d.startsWith('./') && !d.startsWith('/'))
-  //   .map(d => path.relative(config.cayoPath, `${config.projectRoot}/node_modules/${d}`));
-  
+
   entry.dependencies = [];
   for (let i = 0; i < localDeps.length; i++) {
     entry.dependencies.push([localDeps[i], srcRelativeLocalDeps[i]]);
   }
-
 
   const depender = { 
     type: 'entry', 
     path: entry.path, 
     dependencies: absoluteDeps, 
   }
-  await handleDependencies(depender, _cayo);
+
+  try {
+    await handleDependencies(depender, _cayo);
+  } catch (err) {
+    console.log('what');
+    throw new Error(`Parsing dependencies of entry file '${entry.path}'`, { cause: err })
+  }
 }

--- a/lib/core/entry.js
+++ b/lib/core/entry.js
@@ -11,7 +11,7 @@ export async function processEntrySource(entry, page, _cayo) {
   
   let code = `${entry.code}`;
   // Rewrite dependency imports
-  getEntryDependencies(entry, page, _cayo);
+  await getEntryDependencies(entry, page, _cayo);
   for (const [relativeDep, srcRelativeDep] of entry.dependencies) {
     code = code.replace(relativeDep, srcRelativeDep);
   }

--- a/lib/core/entry.js
+++ b/lib/core/entry.js
@@ -1,7 +1,8 @@
+import fs from 'fs-extra';
 import { getEntryDependencies } from './dependencies.js';
 import { generateCayoRuntimeImport } from './codegen.js';
 
-export function processEntrySource(entry, page, _cayo) {
+export async function processEntrySource(entry, page, _cayo) {
   try {
     entry.code = await fs.readFile(entry.path, { encoding: 'utf8' });
   } catch (err) {

--- a/lib/core/entry.js
+++ b/lib/core/entry.js
@@ -1,0 +1,23 @@
+import { getEntryDependencies } from './dependencies.js';
+import { generateCayoRuntimeImport } from './codegen.js';
+
+export function processEntrySource(entry, page, _cayo) {
+  try {
+    entry.code = await fs.readFile(entry.path, { encoding: 'utf8' });
+  } catch (err) {
+    throw err;
+  }
+  
+  let code = `${entry.code}`;
+  // Rewrite dependency imports
+  getEntryDependencies(entry, page, _cayo);
+  for (const [relativeDep, srcRelativeDep] of entry.dependencies) {
+    code = code.replace(relativeDep, srcRelativeDep);
+  }
+  // Prepend cayo runtime import to entry source code
+  if (entry.renderCayos) {
+    code = generateCayoRuntimeImport() + code;
+  }
+
+  return code;
+}

--- a/lib/core/files.js
+++ b/lib/core/files.js
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import chalk from 'chalk';
-import { logger } from './logger.js';
+import logger from './logger.js';
 import { processEntrySource } from './entry.js';
 
 // Write file content for a page

--- a/lib/core/files.js
+++ b/lib/core/files.js
@@ -49,8 +49,6 @@ export async function writePageFiles(page, _cayo) {
         );
     }
   }
-  // Write user entry JS
-  await writeEntryFile(page, _cayo);
 }
 
 export async function writeEntryFile(page, _cayo) {
@@ -59,7 +57,7 @@ export async function writeEntryFile(page, _cayo) {
   
   if (entry.path) {
     // Get the processed entry code
-    let code = processEntrySource(entry, page, _cayo);
+    let code = await processEntrySource(entry, page, _cayo);
     // Write the processed entry file
     let entryOutputPath = page.url === '/' ? `./index.js` : `${page.url}/index.js`;
     await fs.outputFile(path.resolve(config.cayoPath, entryOutputPath), code)

--- a/lib/core/files.js
+++ b/lib/core/files.js
@@ -2,6 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import chalk from 'chalk';
 import { logger } from './logger.js';
+import { processEntrySource } from './entry.js';
 
 // Write file content for a page
 // TODO: wrap all fs stuff in try blocks (need the awaits?)
@@ -56,12 +57,10 @@ export async function writeEntryFile(page, _cayo) {
   const { config } = _cayo;
   const { entry } = page.result;
   
-  if (entry.path && entry.code) {
-    let code = `${entry.code}`;
-    for (const [relativeDep, srcRelativeDep] of entry.dependencies) {
-      code = code.replace(relativeDep, srcRelativeDep);
-    }
-
+  if (entry.path) {
+    // Get the processed entry code
+    let code = processEntrySource(entry, page, _cayo);
+    // Write the processed entry file
     let entryOutputPath = page.url === '/' ? `./index.js` : `${page.url}/index.js`;
     await fs.outputFile(path.resolve(config.cayoPath, entryOutputPath), code)
       .then(() => logger.log.info(

--- a/lib/core/files.js
+++ b/lib/core/files.js
@@ -4,11 +4,11 @@ import chalk from 'chalk';
 import { logger } from './logger.js';
 
 // Write file content for a page
-// TODO: wrap all fs stuff in try blocks
+// TODO: wrap all fs stuff in try blocks (need the awaits?)
 export async function writePageFiles(page, _cayo) {
   const { config } = _cayo;
   const outDir = config.cayoPath;
-  const { html, css, js, entry, cayoAssets } = page.result;
+  const { html, css, js, cayoAssets } = page.result;
   const htmlPath = page.url === '/' ? 'index.html' : `${page.url}/index.html`;
 
   // Write HTML
@@ -48,8 +48,14 @@ export async function writePageFiles(page, _cayo) {
         );
     }
   }
+  // Write user entry JS
+  await writeEntryFile(page, _cayo);
+}
 
-  // Copy user entry JS & its dependencies
+export async function writeEntryFile(page, _cayo) {
+  const { config } = _cayo;
+  const { entry } = page.result;
+  
   if (entry.path && entry.code) {
     let code = `${entry.code}`;
     for (const [relativeDep, absoluteDep] of entry.dependencies) {
@@ -57,7 +63,7 @@ export async function writePageFiles(page, _cayo) {
     }
 
     let entryOutputPath = page.url === '/' ? `./index.js` : `${page.url}/index.js`;
-    await fs.outputFile(path.resolve(outDir, entryOutputPath), code)
+    await fs.outputFile(path.resolve(config.cayoPath, entryOutputPath), code)
       .then(() => logger.log.info(
         chalk.green('entry build ') + chalk.dim(`${page.name}`), 
         { timestamp: true }

--- a/lib/core/files.js
+++ b/lib/core/files.js
@@ -49,10 +49,15 @@ export async function writePageFiles(page, _cayo) {
     }
   }
 
-  // Copy user entry JS
+  // Copy user entry JS & its dependencies
   if (entry.path && entry.code) {
-    let entryRelativePath = page.url === '/' ? `./index.js` : `${page.url}/index.js`;
-    await fs.outputFile(path.resolve(outDir, entryRelativePath), entry.code)
+    let code = `${entry.code}`;
+    for (const [relativeDep, absoluteDep] of entry.dependencies) {
+      code = code.replace(relativeDep, absoluteDep)
+    }
+
+    let entryOutputPath = page.url === '/' ? `./index.js` : `${page.url}/index.js`;
+    await fs.outputFile(path.resolve(outDir, entryOutputPath), code)
       .then(() => logger.log.info(
         chalk.green('entry build ') + chalk.dim(`${page.name}`), 
         { timestamp: true }

--- a/lib/core/files.js
+++ b/lib/core/files.js
@@ -58,8 +58,8 @@ export async function writeEntryFile(page, _cayo) {
   
   if (entry.path && entry.code) {
     let code = `${entry.code}`;
-    for (const [relativeDep, absoluteDep] of entry.dependencies) {
-      code = code.replace(relativeDep, absoluteDep)
+    for (const [relativeDep, srcRelativeDep] of entry.dependencies) {
+      code = code.replace(relativeDep, srcRelativeDep);
     }
 
     let entryOutputPath = page.url === '/' ? `./index.js` : `${page.url}/index.js`;

--- a/lib/core/logger.js
+++ b/lib/core/logger.js
@@ -17,7 +17,9 @@ const errorLogger = (err) => {
   if (err.cause) console.error(chalk.red.bold('> Cause:'), chalk.red.bold(err.cause));
 }
 
-export const logger = { 
+const logger = { 
   log: infoLogger,
   error: errorLogger,
 }
+
+export default logger;

--- a/lib/core/render/prerender.js
+++ b/lib/core/render/prerender.js
@@ -1,11 +1,10 @@
-import fs, { pathExists } from 'fs-extra';
+import fs from 'fs-extra';
 import path from 'path';
 import { JSDOM } from 'jsdom';
-import chalk from 'chalk';
-import { Renderer } from './renderer.js';
-import { logger } from '../logger.js';
-import { generateCayoRuntime } from '../codegen.js';
+import logger from '../logger.js';
 import { generateCayoComponentId } from '../utils.js';
+import { Renderer } from './renderer.js';
+import { generateCayoRuntime, generateRuntimeIssuesScript } from '../codegen.js';
 import { compileCayos } from '../compile/cayos.js';
 
 export async function prerender(page, _cayo) {
@@ -66,6 +65,7 @@ export async function processPage(content, page, _cayo, logger) {
         warnings.cayos[id] = JSON.parse(el.dataset.cayoWarn);
       }
       
+      // Add cayos to stats for dependency handling
       let absoluteSrc = path.resolve(config.components, src);
       if (_cayo.stats.cayoComponents[name]) {
         _cayo.stats.cayoComponents[name].src = absoluteSrc;
@@ -78,12 +78,15 @@ export async function processPage(content, page, _cayo, logger) {
       }
       _cayo.stats.dependencies.pages[page.sourcePath].add(absoluteSrc);      
 
+      // Compile cayos & keep track of them for this page
       const [cayo] = await compileCayos({ [name]: _cayo.stats.cayoComponents[name] }, _cayo);
       if (cayoInstances[name]) {
         cayoInstances[name].push(id);
       } else {
         cayoInstances[name] = [id];
       }
+      // Include the assets needed by a cayo
+      // CSS is the only thing currently output other than the component JS
       if (!cayoAssets[name]) {
         cayoAssets[name] = { 
           css: { 
@@ -134,9 +137,7 @@ export async function processPage(content, page, _cayo, logger) {
         log: `Entry file '${entryScriptSrc}' does not exist.`,
       }
       // Remove the entry file script because the file doesn't exist
-      if (entryScriptPlaceholder) {
-        entryScript.remove();
-      }
+      entryScript.remove();
     } else {
       entry.path = absoluteEntrySrcPath;
       _cayo.stats.dependencies.pages[page.sourcePath].add(absoluteEntrySrcPath);
@@ -152,9 +153,7 @@ export async function processPage(content, page, _cayo, logger) {
       }
     } else {
       // Remove the entry point script tag because the page doesn't need any JS
-      if (entryScript) {
-        entryScript.remove();
-      }
+      entryScript.remove();
     }
   }
 
@@ -162,26 +161,27 @@ export async function processPage(content, page, _cayo, logger) {
   const cayoRuntimePath = page.url === '/' ? `/index.js` : `${page.url}/index.js`;
   js = generateCayoRuntime(cayoInstances, cayoRuntimePath, _cayo);
 
+  // Indicate that we need to make this entry ready to render cayos later,
+  // if there are cayo instances on this page
   if (cayoIds.length > 0) {
-    // Indicate that we need to make this entry ready to render cayos later
     entry.renderCayos = true;
   }
   
-  // Handle runtime warnings  
+  // Append runtime warnings
   const warningScript = generateRuntimeIssuesScript({ config, document, page }, warnings, 'warning');
   if (config.mode === 'development') {
     document.body.appendChild(warningScript);
   }
-  
+  // Append runtime errors
   const errorScript = generateRuntimeIssuesScript({ config, document, page }, errors,  'error');
   if (config.mode === 'development') {
     document.body.appendChild(errorScript);;
   }
 
-  // Construct the correct HTML string based on the document tags
-  // that were rendered from the source (jsdom wraps the source HTML in a document,
+  // Construct the correct HTML string based on the document structure
+  // that was rendered from the source (jsdom wraps the source HTML in a document,
   // which always includes `html`, `head`, and `body`, even if the source doesn't)
-  const tags = findDocumentTags(content.html);
+  const tags = tagsExist(content.html);
   let processedHTML = '';
   if (tags.html) {
     processedHTML = document.documentElement.outerHTML;
@@ -210,84 +210,13 @@ export async function processPage(content, page, _cayo, logger) {
   };
 }
 
-function findDocumentTags(source) {
+function tagsExist(source) {
   const head = source.match(/\<head[\s\S]*\>(?<innerHTML>[\s\S]*)\<\/head\>/g);
   const body = source.match(/\<body[\s\S]*\>(?<innerHTML>[\s\S]*)\<\/body\>/g);
   const html = source.match(/\<html[\s\S]*\>(?<innerHTML>[\s\S]*)\<\/html\>/g);
-
   return {
     head: head === null ? false : true,
     body: body === null ? false : true,
     html: html === null ? false : true,
   };
-}
-
-// TODO: move to codegen.js
-// TODO: add links to relevant docs
-// Generate console warnings that need to show in the browser
-function generateRuntimeIssuesScript(runtime, issues, type) {
-  const { config, document, page } = runtime;
-  const script = document.createElement('script');
-
-  // Formattign and label stuff
-  let prefix = 'Warning';
-  let f_log = (str) => str;
-  let f_prefix = prefix
-  let consoleType = 'log';
-  if (type === 'warning') {
-    prefix = 'Warning';
-    f_log = chalk.yellow;
-    f_prefix = chalk.yellow.bold(prefix);
-    consoleType = 'warn';
-  } else if (type === 'error') {
-    prefix = 'Error';
-    f_log = chalk.redBright;
-    f_prefix = chalk.redBright.bold(prefix);
-    consoleType = 'error';
-  }
-  
-  const { 
-    cayos: cayoIssues, 
-    page: pageIssues,
-  } = issues;
-
-  script.innerHTML = `/* ${prefix}s for this page. See issues in console. */\n`;
-
-  // Handle issues derived during initial compilation
-  if (Object.keys(cayoIssues).length > 0) {
-    for (const cayoId in cayoIssues) {
-      let message = `Cayo ${prefix}: Cayo '${cayoId}' has runtime issues.\n\n`;
-      for (const key in cayoIssues[cayoId]) {
-        const issue = cayoIssues[cayoId][key];
-        message += `${issue.title}: ${issue.message}\n\n`;
-        if (cayoId !== 'undefined') {
-          message += `Hint: review instances of <Cayo src="${issue.src}"> intended to be rendered on page '${page.sourcePath.replace(config.pages, '')}'\n`;
-        } else {
-          message += `Hint: review instances of <Cayo src={<undefined>}> or <Cayo> without a src prop intended to be rendered on page '${page.sourcePath.replace(config.pages, '')}'\n`;
-        }
-        if (issue.log) {
-          logger.log.info(
-            `${f_log(`${f_prefix}: ${issue.log}`)} ${chalk.dim(`${page.name}`)}`, 
-            { timestamp: true, clear: false, }
-          );
-        }
-      }
-      script.innerHTML += `console.${consoleType}(\`${message}\`);\n`;
-    }
-  }
-  // Handle issues based on parsing the rendered HTML
-  if (Object.keys(pageIssues).length > 0) {
-    for (const key in pageIssues) {
-      const issue = pageIssues[key];
-      let message = `${prefix}: page '${page.name}' has runtime issues.\n\n`;
-      message += `${issue.title}: ${issue.message}\n\n`;
-      script.innerHTML += `console.${consoleType}(\`${message}\`);\n`;
-      logger.log.info(
-        `${f_log(`${f_prefix}: ${issue.log}`)} ${chalk.dim(`${page.name}`)}`, 
-        { timestamp: true, clear: false, }
-      );
-    }
-  }
-
-  return script;
 }

--- a/lib/core/render/prerender.js
+++ b/lib/core/render/prerender.js
@@ -7,9 +7,6 @@ import { logger } from '../logger.js';
 import { generateCayoRuntime } from '../codegen.js';
 import { generateCayoComponentId } from '../utils.js';
 import { compileCayos } from '../compile/cayos.js';
-import { getDeps } from '../bundle.js';
-import { handleDependencies } from '../dependencies.js';
-import precinct from 'precinct';
 
 export async function prerender(page, _cayo) {
   const renderer = new Renderer(page.layout);
@@ -144,15 +141,8 @@ export async function processPage(content, page, _cayo, logger) {
           entryScriptPlaceholder.remove();
         }
       } else {
-        try {
-          const entrySource = await fs.readFile(entryFilePath, { encoding: 'utf8' });
-          if (entrySource) entry.code = entrySource;
-          entry.path = entryFilePath;
-          _cayo.stats.dependencies.pages[page.sourcePath].add(entry.path);
-          handleEntryDependencies(page, entry, _cayo);
-        } catch (err) {
-          throw err;
-        }
+        entry.path = entryFilePath;
+        _cayo.stats.dependencies.pages[page.sourcePath].add(entry.path);
       }
 
     } else {
@@ -185,10 +175,9 @@ export async function processPage(content, page, _cayo, logger) {
   const cayoRuntimePath = page.url === '/' ? `/index.js` : `${page.url}/index.js`;
   js = generateCayoRuntime(cayoInstances, cayoRuntimePath, _cayo);
 
-  // Prepend cayo runtime import to entry source code
   if (cayoIds.length > 0) {
-    entry.code = `import { default as renderCayos } from './cayo-runtime.js';\n` 
-      + entry.code;
+    // Indicate that we need to make this entry ready to render cayos later
+    entry.renderCayos = true;
   }
   
   // Handle runtime warnings  
@@ -313,32 +302,4 @@ function generateRuntimeIssuesScript(runtime, issues, type) {
   }
 
   return script;
-}
-
-async function handleEntryDependencies(page, entry, _cayo) {
-  const { config } = _cayo;
-  let imports = precinct(entry.code, { type: 'es6', includeCore: false });
-  // Filter out public path ('/') and node_modules ('<package>')
-  let localDeps = imports.filter(d => d.startsWith('../') || d.startsWith('./'));
-  let absoluteDeps = localDeps.map(d => path.resolve(path.dirname(entry.path), d));
-  let srcRelativeLocalDeps = localDeps.map((d, i) => {
-    let pageCayoPath = path.resolve(config.cayoPath, page.url === '/' ? './' : page.url);
-    return path.relative(pageCayoPath, absoluteDeps[i]);
-  });
-  // let nodeModules = imports
-  //   .filter(d => !d.startsWith('../') && !d.startsWith('./') && !d.startsWith('/'))
-  //   .map(d => path.relative(config.cayoPath, `${config.projectRoot}/node_modules/${d}`));
-  
-  entry.dependencies = [];
-  for (let i = 0; i < localDeps.length; i++) {
-    entry.dependencies.push([localDeps[i], srcRelativeLocalDeps[i]]);
-  }
-
-
-  const depender = { 
-    type: 'entry', 
-    path: entry.path, 
-    dependencies: absoluteDeps, 
-  }
-  await handleDependencies(depender, _cayo);
 }

--- a/lib/core/render/prerender.js
+++ b/lib/core/render/prerender.js
@@ -7,6 +7,8 @@ import { logger } from '../logger.js';
 import { generateCayoRuntime } from '../codegen.js';
 import { generateCayoComponentId } from '../utils.js';
 import { compileCayos } from '../compile/cayos.js';
+import { getDeps } from '../bundle.js';
+import { handleDependencies } from '../dependencies.js';
 
 export async function prerender(page, _cayo) {
   const renderer = new Renderer(page.layout);
@@ -142,6 +144,9 @@ export async function processPage(content, page, _cayo, logger) {
         }
       } else {
         entry.path = entryFilePath;
+        _cayo.stats.dependencies.pages[page.sourcePath].add(entry.path);
+        handleEntryDependencies(entry.path, _cayo);
+        // _cayo.stats.dependencies.entries[entry.path];
         try {
           const entrySource = await fs.readFile(entryFilePath, { encoding: 'utf8' });
           if (entrySource) entry.code = entrySource;
@@ -308,4 +313,13 @@ function generateRuntimeIssuesScript(runtime, issues, type) {
   }
 
   return script;
+}
+
+async function handleEntryDependencies(entryPath, _cayo) {
+  const depender = { 
+    type: 'entry', 
+    path: entryPath, 
+    dependencies: await getDeps(entryPath, _cayo), 
+  }
+  await handleDependencies(depender, _cayo);
 }

--- a/lib/core/render/prerender.js
+++ b/lib/core/render/prerender.js
@@ -149,7 +149,7 @@ export async function processPage(content, page, _cayo, logger) {
           if (entrySource) entry.code = entrySource;
           entry.path = entryFilePath;
           _cayo.stats.dependencies.pages[page.sourcePath].add(entry.path);
-          handleEntryDependencies(entry, _cayo);
+          handleEntryDependencies(page, entry, _cayo);
         } catch (err) {
           throw err;
         }
@@ -315,13 +315,25 @@ function generateRuntimeIssuesScript(runtime, issues, type) {
   return script;
 }
 
-async function handleEntryDependencies(entry, _cayo) {
-  const relativeDeps = precinct(entry.code, { type: 'es6' });
-  const absoluteDeps = relativeDeps.map(d => path.resolve(path.dirname(entry.path), d));
+async function handleEntryDependencies(page, entry, _cayo) {
+  const { config } = _cayo;
+  let imports = precinct(entry.code, { type: 'es6', includeCore: false });
+  // Filter out public path ('/') and node_modules ('<package>')
+  let localDeps = imports.filter(d => d.startsWith('../') || d.startsWith('./'));
+  let absoluteDeps = localDeps.map(d => path.resolve(path.dirname(entry.path), d));
+  let srcRelativeLocalDeps = localDeps.map((d, i) => {
+    let pageCayoPath = path.resolve(config.cayoPath, page.url === '/' ? './' : page.url);
+    return path.relative(pageCayoPath, absoluteDeps[i]);
+  });
+  // let nodeModules = imports
+  //   .filter(d => !d.startsWith('../') && !d.startsWith('./') && !d.startsWith('/'))
+  //   .map(d => path.relative(config.cayoPath, `${config.projectRoot}/node_modules/${d}`));
+  
   entry.dependencies = [];
-  for (let i = 0; i < absoluteDeps.length; i++) {
-    entry.dependencies.push([relativeDeps[i], absoluteDeps[i]]);
+  for (let i = 0; i < localDeps.length; i++) {
+    entry.dependencies.push([localDeps[i], srcRelativeLocalDeps[i]]);
   }
+
 
   const depender = { 
     type: 'entry', 

--- a/lib/core/render/prerender.js
+++ b/lib/core/render/prerender.js
@@ -114,47 +114,34 @@ export async function processPage(content, page, _cayo, logger) {
   const cayoAssetsCssMarker = document.querySelector('link[data-cayo-assets-css]');
   cayoAssetsCssMarker.outerHTML = cayoAssetCssElements;
 
-  // Get user-specified entry file name
-  const entryScript = document.querySelector('script[data-cayo-entry]');
-  let userEntryFile = entryScript ? entryScript.src : '';
+  // Get user-specified entry placeholder
+  const entryScriptPlaceholder = document.querySelector('script[data-cayo-entry]');
+  let entryScriptSrc = entryScriptPlaceholder ? entryScriptPlaceholder.src : '';
   // This is injected by Renderer.render based on the template
-  const entryScriptPlaceholder = document.querySelector(`script[type="module"][src="./index.js"]`);
+  const entryScript = document.querySelector(`script[type="module"][src="./index.js"]`);
 
-  if (userEntryFile) {
-    // User entry file defined
+  if (entryScriptSrc) {
     // Remove user-specified entry file placeholder
-    entryScript.remove();
+    entryScriptPlaceholder.remove();
     // Validate the file path
-    if (userEntryFile.startsWith('/')) {
-      userEntryFile = userEntryFile.substring(1);
-      const entryFilePath = path.resolve(config.src, userEntryFile);
-      if (!fs.pathExistsSync(entryFilePath)) {
-        let relativePath = entryFilePath.replace(config.projectRoot, '');
-        errors.page.entryFileDoesNotExist = {
-          title: `Bad entry file`,
-          src: page.sourcePath.replace(config.pages, ''),
-          message: `Entry file '${relativePath}' does not exist.`,
-          log: `Entry file '${userEntryFile}' does not exist.`,
-        }
-        // Remove the placeholder entry file script tag because the file doesn't exist
-        if (entryScriptPlaceholder) {
-          entryScriptPlaceholder.remove();
-        }
-      } else {
-        entry.path = entryFilePath;
-        _cayo.stats.dependencies.pages[page.sourcePath].add(entry.path);
-      }
-
-    } else {
-      errors.page.entryNotRelative = {
+    const absoluteEntrySrcPath = path.resolve(config.src, entryScriptSrc);
+    if (!fs.pathExistsSync(absoluteEntrySrcPath)) {
+      let relativePath = entryScriptSrc.replace(config.projectRoot, '');
+      errors.page.entryFileDoesNotExist = {
         title: `Bad entry file`,
         src: page.sourcePath.replace(config.pages, ''),
-        message: `Entry file path '${userEntryFile}' requires a leading slash and to be relative to the src path.`,
-        log: `Bad entry file: '${userEntryFile}'. Entry files paths require a leading slash and to be relative to the src path.'`,
+        message: `Entry file '${relativePath}' does not exist.`,
+        log: `Entry file '${entryScriptSrc}' does not exist.`,
       }
+      // Remove the entry file script because the file doesn't exist
+      if (entryScriptPlaceholder) {
+        entryScript.remove();
+      }
+    } else {
+      entry.path = absoluteEntrySrcPath;
+      _cayo.stats.dependencies.pages[page.sourcePath].add(absoluteEntrySrcPath);
     }
   } else {
-    // User entry file not defined  
     if (cayoIds.length > 0) {
       let message = 'An entry file is required in order to render Cayos on the page.'
       warnings.page.noEntryFile = {
@@ -165,8 +152,8 @@ export async function processPage(content, page, _cayo, logger) {
       }
     } else {
       // Remove the entry point script tag because the page doesn't need any JS
-      if (entryScriptPlaceholder) {
-        entryScriptPlaceholder.remove();
+      if (entryScript) {
+        entryScript.remove();
       }
     }
   }
@@ -235,6 +222,7 @@ function findDocumentTags(source) {
   };
 }
 
+// TODO: move to codegen.js
 // TODO: add links to relevant docs
 // Generate console warnings that need to show in the browser
 function generateRuntimeIssuesScript(runtime, issues, type) {

--- a/lib/core/render/prerender.js
+++ b/lib/core/render/prerender.js
@@ -9,6 +9,7 @@ import { generateCayoComponentId } from '../utils.js';
 import { compileCayos } from '../compile/cayos.js';
 import { getDeps } from '../bundle.js';
 import { handleDependencies } from '../dependencies.js';
+import precinct from 'precinct';
 
 export async function prerender(page, _cayo) {
   const renderer = new Renderer(page.layout);
@@ -143,13 +144,12 @@ export async function processPage(content, page, _cayo, logger) {
           entryScriptPlaceholder.remove();
         }
       } else {
-        entry.path = entryFilePath;
-        _cayo.stats.dependencies.pages[page.sourcePath].add(entry.path);
-        handleEntryDependencies(entry.path, _cayo);
-        // _cayo.stats.dependencies.entries[entry.path];
         try {
           const entrySource = await fs.readFile(entryFilePath, { encoding: 'utf8' });
           if (entrySource) entry.code = entrySource;
+          entry.path = entryFilePath;
+          _cayo.stats.dependencies.pages[page.sourcePath].add(entry.path);
+          handleEntryDependencies(entry, _cayo);
         } catch (err) {
           throw err;
         }
@@ -315,11 +315,18 @@ function generateRuntimeIssuesScript(runtime, issues, type) {
   return script;
 }
 
-async function handleEntryDependencies(entryPath, _cayo) {
+async function handleEntryDependencies(entry, _cayo) {
+  const relativeDeps = precinct(entry.code, { type: 'es6' });
+  const absoluteDeps = relativeDeps.map(d => path.resolve(path.dirname(entry.path), d));
+  entry.dependencies = [];
+  for (let i = 0; i < absoluteDeps.length; i++) {
+    entry.dependencies.push([relativeDeps[i], absoluteDeps[i]]);
+  }
+
   const depender = { 
     type: 'entry', 
-    path: entryPath, 
-    dependencies: await getDeps(entryPath, _cayo), 
+    path: entry.path, 
+    dependencies: absoluteDeps, 
   }
   await handleDependencies(depender, _cayo);
 }

--- a/scripts/compileCayoComponent.js
+++ b/scripts/compileCayoComponent.js
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import { validateConfig, loadConfig } from '../lib/core/config.js';
 import { build } from '../lib/core/bundle.js';
-import { logger } from '../lib/core/logger.js';
+import logger from '../lib/core/logger.js';
 import chalk from 'chalk';
 import path from 'path';
 


### PR DESCRIPTION
Handle files like entry files and their dependencies. 

### Entry Files
Since we're using vite, we just need to rewrite the imports to be absolute. The entry source is processed and then output into `.cayo`. Once vite is serving, it watches for those file changes and runs HMR updates. 

Still need to watch/handle the nested JS dependencies, but not Sass (which is handled well, just by the way this works with Sass + Vite).

**To Do:**
- [x] Would need to break out the `writeEntryFile()` functionality to not be coupled with `writePageFiles()`, but rather need to be run by `cli/watch.js` and `cli/index.js`.
- [x] Make `writeEntryFile()` fire for all relevant pages with the same entry
- Files to Support
  - [x] Entry Files (JS)
  - [x] JS
  - [x] CSS/SCSS
  - [x] JSON? (~~I think dependent on user config plugins~~ I just added it as a default rollup plugin along with css so this always works)


---

### Fixes
- Fix #76
- Fix #71
- Fix #44