### PR TITLE
feat/components-anywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,12 @@ public/
 ```
 
 ### Source Directory
-Most of your projects files should go in `src`. This is where pages, components, styles, etc. should go. These files will be watched while running `cayo dev`, and used to build your project.
+Most of your project files, such as pages, cayos, styles, etc. should go in `src`.
 - `pages` contains the pages, or "inputs" of your project 
 - `components` contains your Cayo Components, and can contain any other components
-- `__template.svelte` is your page template 
+- `__template.svelte` is your page template
+
+Note: `cayo` watches and builds from the project root, but certain paths are expected as relative to the source directory rather than the root, e.g., cayos and pages. Read the config reference for more information.
 
 ### Pages
 Cayo uses a file-based routing system, meaning the file structure within the pages directory gets used to generate output files. All pages are expected to be valid Svelte components. Since your outputs just become regular old HTML files, there is no real "routing" going on here beyond the expected default of HTML files being served on a web server. 

--- a/dist/cayo.svelte.js
+++ b/dist/cayo.svelte.js
@@ -70,11 +70,17 @@ const Cayo = create_ssr_component(($$result, $$props, $$bindings, slots) => {
 		cayoInstanceData['data-cayo-warn'] = JSON.stringify(warnings);
 	}
 
+	delete cayoInstanceData['class'];
 	if ($$props.src === void 0 && $$bindings.src && src !== void 0) $$bindings.src(src);
 
 	return `<div${spread([escape_object(cayoInstanceData)], {})}>
   ${slots.default ? slots.default({}) : ``}
-</div>`;
+</div>
+
+<!-- data-cayo-id={cayoInstanceData['data-cayo-id']}
+data-cayo-src={cayoInstanceData['data-cayo-src']}
+data-cayo-props={cayoInstanceData['data-cayo-props']}
+data-cayo-warn={cayoInstanceData['data-cayo-warn']} -->`;
 });
 
 export { Cayo as default };

--- a/dist/cayo.svelte.js
+++ b/dist/cayo.svelte.js
@@ -1,4 +1,4 @@
-import { create_ssr_component, compute_rest_props, spread, escape_object } from 'svelte/internal';
+import { create_ssr_component, compute_rest_props, add_attribute } from 'svelte/internal';
 
 function getWarnings(src, badProps) {
   const warnings = {};
@@ -70,17 +70,11 @@ const Cayo = create_ssr_component(($$result, $$props, $$bindings, slots) => {
 		cayoInstanceData['data-cayo-warn'] = JSON.stringify(warnings);
 	}
 
-	delete cayoInstanceData['class'];
 	if ($$props.src === void 0 && $$bindings.src && src !== void 0) $$bindings.src(src);
 
-	return `<div${spread([escape_object(cayoInstanceData)], {})}>
+	return `<div${add_attribute("data-cayo-id", cayoInstanceData['data-cayo-id'], 0)}${add_attribute("data-cayo-src", cayoInstanceData['data-cayo-src'], 0)}${add_attribute("data-cayo-props", cayoInstanceData['data-cayo-props'], 0)}${add_attribute("data-cayo-warn", cayoInstanceData['data-cayo-warn'], 0)}>
   ${slots.default ? slots.default({}) : ``}
-</div>
-
-<!-- data-cayo-id={cayoInstanceData['data-cayo-id']}
-data-cayo-src={cayoInstanceData['data-cayo-src']}
-data-cayo-props={cayoInstanceData['data-cayo-props']}
-data-cayo-warn={cayoInstanceData['data-cayo-warn']} -->`;
+</div>`;
 });
 
 export { Cayo as default };

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -37,7 +37,7 @@ Check out [more config examples](#more-examples).
 - **Type**: `string`
 - **Default**: `'.'`
 
-The project root directory, where Cayo will look for the required project structure. Can be an absolute path or a directory relative to the current working directory. 
+The project root directory, where Cayo will look for the required project structure. Can be an absolute path or a directory relative to the current working directory. This folder will be watched for changes during dev.
 
 ---
 
@@ -45,7 +45,7 @@ The project root directory, where Cayo will look for the required project struct
 - **Type**: `string`
 - **Default**: `'src'`
 
-Specify the directory where your source files will be, relative to the [project root](#projectroot). This folder will be watched for changes during dev. 
+Specify the directory where your source files will be, relative to the [project root](#projectroot).
 
 ---
 

--- a/lib/cli/watch.js
+++ b/lib/cli/watch.js
@@ -10,7 +10,7 @@ import { debugStats } from '#core/utils.js';
 export function watch(_cayo) {
   const { config } = _cayo;
 
-  const watcher = chokidar.watch(config.src, {
+  const watcher = chokidar.watch(config.projectRoot, {
     // awaitWriteFinish: {
     //   stabilityThreshold: 1,
     //   pollInterval: 250
@@ -61,7 +61,7 @@ export function watch(_cayo) {
           await handleCayo(filepath, _cayo);
 
         // Handle Components
-        } else if (filepath.startsWith(config.components)) {
+        } else if (!filepath.startsWith(config.pages)) {
           logChange('component', filepath);
           await handleComponent(filepath, _cayo);
         }

--- a/lib/core/render/prerender.js
+++ b/lib/core/render/prerender.js
@@ -59,7 +59,6 @@ export async function processPage(content, page, _cayo, logger) {
       const { id, name } = generateCayoComponentId(src);
       cayoIds.push(id);
       el.dataset.cayoId = id;
-      console.log(el.outerHTML);
 
       // Get warnings added by the Cayo component during compile time
       if (el.dataset.cayoWarn && el.dataset.cayoWarn !== '{}') {

--- a/lib/core/render/prerender.js
+++ b/lib/core/render/prerender.js
@@ -59,6 +59,7 @@ export async function processPage(content, page, _cayo, logger) {
       const { id, name } = generateCayoComponentId(src);
       cayoIds.push(id);
       el.dataset.cayoId = id;
+      console.log(el.outerHTML);
 
       // Get warnings added by the Cayo component during compile time
       if (el.dataset.cayoWarn && el.dataset.cayoWarn !== '{}') {

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -18,6 +18,7 @@ export function hash(str = '', bytes = 5) {
 export function generateSafeName(inputPath) {
   return inputPath
     .replace(/^\.\//g, '')
+    .replace(/^\.\./g, '__')
     .replace(/\/+/g, '__')
     .replace(/\-+/g, '_');
 }

--- a/lib/core/utils.js
+++ b/lib/core/utils.js
@@ -16,17 +16,20 @@ export function hash(str = '', bytes = 5) {
 }
 
 export function generateSafeName(inputPath) {
-  return inputPath
+  let safeName = inputPath
     .replace(/^\.\//g, '')
-    .replace(/^\.\./g, '__')
+    .replace(/\.\.\//g, '')
     .replace(/\/+/g, '__')
     .replace(/\-+/g, '_');
+
+  // safeName += `_${hash(inputPath)}`;
+  return { name: safeName, suffix: hash(inputPath) };
 }
 
 export function generateCayoComponentId(componentPath) {
-  const name = generateSafeName(componentPath)
-    .replace('.cayo.svelte', '');
-  
+  let { name, suffix } = generateSafeName(componentPath)
+  name = name.replace('.cayo.svelte', ''); 
+  name += `_${suffix}`;
   const id = `${name}-${hash(name)}`;
 
   return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cayo",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "start": "node cayo dev --projectRoot test",

--- a/src/cayo.svelte
+++ b/src/cayo.svelte
@@ -29,8 +29,15 @@
     cayoInstanceData['data-cayo-warn'] = JSON.stringify(warnings);
   }
 
+  delete cayoInstanceData['class'];
 </script>
-
-<div {...cayoInstanceData}>
+<div 
+  data-cayo-id={cayoInstanceData['data-cayo-id']}
+  data-cayo-src={cayoInstanceData['data-cayo-src']}
+  data-cayo-props={cayoInstanceData['data-cayo-props']}
+  data-cayo-warn={cayoInstanceData['data-cayo-warn']}
+>
   <slot/>
 </div>
+
+

--- a/src/cayo.svelte
+++ b/src/cayo.svelte
@@ -28,8 +28,6 @@
   if (warnings) {
     cayoInstanceData['data-cayo-warn'] = JSON.stringify(warnings);
   }
-
-  delete cayoInstanceData['class'];
 </script>
 <div 
   data-cayo-id={cayoInstanceData['data-cayo-id']}


### PR DESCRIPTION
### feat/components-anywhere

**Changes:**

- projectRoot is now the watch dir instead of src
- components can now be in any dir within projectRoot (except for the pages dir)
- fixed bug where `class="[Object object]"` would be an attribute of every Cayo placeholder