### PR TITLE
v 1.2.0

### DIFF
--- a/dist/cayo.svelte.js
+++ b/dist/cayo.svelte.js
@@ -57,13 +57,16 @@ const Cayo = create_ssr_component(($$result, $$props, $$bindings, slots) => {
 
 		return value;
 	}
-	const json = JSON.stringify({ ...$$restProps }, replacer);
+
+	// const props = toSource({...$$restProps})
+	const props = JSON.stringify({ ...$$restProps }, replacer);
+
 	const warnings = getWarnings(src, badProps);
 
 	const cayoInstanceData = {
-		'data-cayo-id': '',
 		'data-cayo-src': !warnings.invalidSrc ? `${src}` : '',
-		'data-cayo-props': json
+		'data-cayo-id': '', // will get set during prerender process based on the src
+		
 	};
 
 	if (warnings) {
@@ -72,7 +75,8 @@ const Cayo = create_ssr_component(($$result, $$props, $$bindings, slots) => {
 
 	if ($$props.src === void 0 && $$bindings.src && src !== void 0) $$bindings.src(src);
 
-	return `<div${add_attribute("data-cayo-id", cayoInstanceData['data-cayo-id'], 0)}${add_attribute("data-cayo-src", cayoInstanceData['data-cayo-src'], 0)}${add_attribute("data-cayo-props", cayoInstanceData['data-cayo-props'], 0)}${add_attribute("data-cayo-warn", cayoInstanceData['data-cayo-warn'], 0)}>
+	return `<div${add_attribute("data-cayo-id", cayoInstanceData['data-cayo-id'], 0)}${add_attribute("data-cayo-src", cayoInstanceData['data-cayo-src'], 0)}${add_attribute("data-cayo-warn", cayoInstanceData['data-cayo-warn'], 0)}>
+  ${`<script data-cayo-props type="application/json">${props}</script>`}
   ${slots.default ? slots.default({}) : ``}
 </div>`;
 });

--- a/lib/core/bundle.js
+++ b/lib/core/bundle.js
@@ -70,10 +70,15 @@ export async function getDeps(input, config) {
 }
 
 export async function build(input, config, type = 'page') {
-  const ssr = (type === 'page' || type === 'template');
+  const template = (type === 'page' || type === 'template');
   const requiredCompilerOptions = {
-    generate: ssr ? 'ssr' : 'dom', 
-    hydratable: ssr ? false : true, 
+    generate: template ? 'ssr' : 'dom', 
+    hydratable: template ? false : true, 
+    preserveComments: template 
+      ? false
+      : config.svelte.compilerOptions.preserveComments
+        ? config.svelte.compilerOptions.preserveComments
+        : true,
   }
 
   let bundle;
@@ -95,7 +100,6 @@ export async function build(input, config, type = 'page') {
           ...preprocessors,
         ],
         compilerOptions: {
-          preserveComments: true,
           preserveWhitespace: true,
           ...config.svelte.compilerOptions,
           ...requiredCompilerOptions,

--- a/lib/core/codegen.js
+++ b/lib/core/codegen.js
@@ -6,7 +6,8 @@ export function generateGetProps() {
   return (
 `
 function getProps(cayoElement) {
-  const json = cayoElement.dataset.cayoProps;
+  const json = cayoElement.querySelector('[data-cayo-props]').innerHTML;
+  console.log('json', json);
   return JSON.parse(json);
 }
 `

--- a/lib/core/render/prerender.js
+++ b/lib/core/render/prerender.js
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { JSDOM } from 'jsdom';
+import chalk from 'chalk';
 import { Renderer } from './renderer.js';
 import { compileCayos } from '../compile/cayos.js';
 import { generateCayoRuntime, generateRuntimeIssuesScript } from '../codegen.js';
@@ -116,7 +117,16 @@ export async function processPage(content, page, _cayo, logger) {
     }
   }
   const cayoAssetsCssMarker = document.querySelector('link[data-cayo-assets-css]');
-  cayoAssetsCssMarker.outerHTML = cayoAssetCssElements;
+  if (cayoAssetsCssMarker && cayoAssetsCssMarker.outerHTML) {
+    cayoAssetsCssMarker.outerHTML = cayoAssetCssElements;
+  } else {
+    if (cayoAssetCssElements) {
+      logger.log.info(
+        chalk.yellow.bold('Warning') + chalk.yellow(': No %cayo.css% found in template, but there is CSS used in source files.'),
+        { timestamp: true, clear: false, }
+      );
+    }
+  }
 
   // Get user-specified entry placeholder
   const entryScriptPlaceholder = document.querySelector('script[data-cayo-entry]');

--- a/lib/core/render/prerender.js
+++ b/lib/core/render/prerender.js
@@ -148,7 +148,7 @@ export async function processPage(content, page, _cayo, logger) {
         log: `Entry file '${entryScriptSrc}' does not exist.`,
       }
       // Remove the entry file script because the file doesn't exist
-      entryScript.remove();
+      entryScript?.remove();
     } else {
       entry.path = absoluteEntrySrcPath;
       _cayo.stats.dependencies.pages[page.sourcePath].add(absoluteEntrySrcPath);
@@ -164,7 +164,7 @@ export async function processPage(content, page, _cayo, logger) {
       }
     } else {
       // Remove the entry point script tag because the page doesn't need any JS
-      entryScript.remove();
+      entryScript?.remove();
     }
   }
 
@@ -209,22 +209,37 @@ export async function processPage(content, page, _cayo, logger) {
   let processedHTML = '';
   if (tags.doctype) {
     processedHTML += tags.doctype;
-  }  
-  if (tags.html) {
-    processedHTML += document.documentElement.outerHTML;
-  } else {
-    if (tags.head) {
-      processedHTML += document.head.outerHTML;
-    } else {
-      processedHTML += document.head.innerHTML;
-    }
+  } 
+  console.log(tags);
 
-    if (tags.body) {
-      processedHTML += document.body.outerHTML;
-    } else {
-      processedHTML += document.body.innerHTML;
-    }
+  let html; // html element parts (open/close tag, inner)
+  let head;
+  if (tags.html) {
+    ({groups: html} = document.documentElement.outerHTML
+      .match(/(?<open><html[\s\S]*?>)(?<innerHTML>[\s\S]*)(?<close><\/html>)/)
+    )
+    processedHTML += html.open;
+  } 
+  if (tags.head) {
+    ({groups: head} = document.head.outerHTML
+      .match(/(?<open><head[\s\S]*?>)(?<innerHTML>[\s\S]*)(?<close><\/head>)/)
+    )
+    console.log('yerrr', tags.head.innerHTML);
+    console.log(head);
+    // processedHTML += '<!-- user head -->' + head.open + tags.head.innerHTML + head.close + '<!-- user head end-->';
+    // processedHTML += head.open + tags.head.innerHTML + head.close;
+    processedHTML += document.head.outerHTML;
+  } else {
+    processedHTML += document.head.innerHTML;
   }
+  if (tags.body) {
+    processedHTML += document.body.outerHTML;
+  } else {
+    processedHTML += document.body.innerHTML;
+  }
+  if (tags.html) {
+    processedHTML += html.close;
+  } 
 
   return { 
     html: processedHTML, 
@@ -237,14 +252,14 @@ export async function processPage(content, page, _cayo, logger) {
 }
 
 function tagsExist(source) {
-  const doctype = source.match(/(?<!<!--\s*)\<!DOCTYPE\s\w*\>/g);
-  const head = source.match(/(?<!<!--\s*)\<head[\s\S]*\>(?<innerHTML>[\s\S]*)\<\/head\>/g);
-  const body = source.match(/(?<!<!--\s*)\<body[\s\S]*\>(?<innerHTML>[\s\S]*)\<\/body\>/g);
-  const html = source.match(/(?<!<!--\s*)\<html[\s\S]*\>(?<innerHTML>[\s\S]*)\<\/html\>/g);
+  const doctype = source.match(/<!DOCTYPE[\s\S]*>/);
+  const head = source.match(/<head[\s\S]*>(?<innerHTML>[\s\S]*)<\/head>/);
+  const body = source.match(/<body[\s\S]*>(?<innerHTML>[\s\S]*)<\/body>/);
+  const html = source.match(/<html[\s\S]*>(?<innerHTML>[\s\S]*)<\/html>/);
   return {
     doctype: doctype === null ? false : doctype,
-    head: head === null ? false : true,
-    body: body === null ? false : true,
-    html: html === null ? false : true,
+    html: html === null ? false : html.groups,
+    head: head === null ? false : head.groups,
+    body: body === null ? false : body.groups,
   };
 }

--- a/lib/core/render/prerender.js
+++ b/lib/core/render/prerender.js
@@ -57,10 +57,11 @@ export async function processPage(content, page, _cayo, logger) {
   for (const el of document.querySelectorAll('[data-cayo-src]')) {
     let src = el.dataset.cayoSrc;
     if (src !== '') {
+      // Generate an ID for the Cayo
       const { id, name } = generateCayoComponentId(src);
       cayoIds.push(id);
       el.dataset.cayoId = id;
-
+      
       // Get warnings added by the Cayo component during compile time
       if (el.dataset.cayoWarn && el.dataset.cayoWarn !== '{}') {
         warnings.cayos[id] = JSON.parse(el.dataset.cayoWarn);

--- a/lib/core/render/prerender.js
+++ b/lib/core/render/prerender.js
@@ -223,9 +223,6 @@ export async function processPage(content, page, _cayo, logger) {
     ({groups: head} = document.head.outerHTML
       .match(/(?<open><head[\s\S]*?>)(?<innerHTML>[\s\S]*)(?<close><\/head>)/)
     )
-    console.log(head);
-    // processedHTML += '<!-- user head -->' + head.open + tags.head.innerHTML + head.close + '<!-- user head end-->';
-    // processedHTML += head.open + tags.head.innerHTML + head.close;
     processedHTML += document.head.outerHTML;
   } else {
     processedHTML += document.head.innerHTML;

--- a/lib/core/render/prerender.js
+++ b/lib/core/render/prerender.js
@@ -209,8 +209,7 @@ export async function processPage(content, page, _cayo, logger) {
   let processedHTML = '';
   if (tags.doctype) {
     processedHTML += tags.doctype;
-  } 
-  console.log(tags);
+  }
 
   let html; // html element parts (open/close tag, inner)
   let head;
@@ -224,7 +223,6 @@ export async function processPage(content, page, _cayo, logger) {
     ({groups: head} = document.head.outerHTML
       .match(/(?<open><head[\s\S]*?>)(?<innerHTML>[\s\S]*)(?<close><\/head>)/)
     )
-    console.log('yerrr', tags.head.innerHTML);
     console.log(head);
     // processedHTML += '<!-- user head -->' + head.open + tags.head.innerHTML + head.close + '<!-- user head end-->';
     // processedHTML += head.open + tags.head.innerHTML + head.close;

--- a/lib/core/render/prerender.js
+++ b/lib/core/render/prerender.js
@@ -227,10 +227,10 @@ export async function processPage(content, page, _cayo, logger) {
 }
 
 function tagsExist(source) {
-  const doctype = source.match(/\<!DOCTYPE\s\w*\>/g);
-  const head = source.match(/\<head[\s\S]*\>(?<innerHTML>[\s\S]*)\<\/head\>/g);
-  const body = source.match(/\<body[\s\S]*\>(?<innerHTML>[\s\S]*)\<\/body\>/g);
-  const html = source.match(/\<html[\s\S]*\>(?<innerHTML>[\s\S]*)\<\/html\>/g);
+  const doctype = source.match(/(?<!<!--\s*)\<!DOCTYPE\s\w*\>/g);
+  const head = source.match(/(?<!<!--\s*)\<head[\s\S]*\>(?<innerHTML>[\s\S]*)\<\/head\>/g);
+  const body = source.match(/(?<!<!--\s*)\<body[\s\S]*\>(?<innerHTML>[\s\S]*)\<\/body\>/g);
+  const html = source.match(/(?<!<!--\s*)\<html[\s\S]*\>(?<innerHTML>[\s\S]*)\<\/html\>/g);
   return {
     doctype: doctype === null ? false : doctype,
     head: head === null ? false : true,

--- a/lib/core/render/renderer.js
+++ b/lib/core/render/renderer.js
@@ -37,19 +37,15 @@ export class Renderer {
     // https://stackoverflow.com/questions/9423722/string-replace-weird-behavior-when-using-dollar-sign-as-replacement
     return {
       html: this.template.html
-        // Ignore placeholders wrapped in HTML comments
-        .replace(/<!--\s*%cayo\.\w+%[\s\S]*?(-->)/g, '')
+        // Strip placeholders wrapped in HTML comments
+        .replace(/<!--[\s\S]?%cayo\.\w+%[\s\S]*?(-->)/g, '')
         // Inject markup in the cayo placeholders
         .replace('%cayo.title%', () => !head.includes('<title>') ? title() : '')
         .replace('%cayo.head%', () => head)
         .replace('%cayo.body%', () => html)
         .replace('%cayo.css%', () => cssElements)
-        // .replace(/(?<!<!--[\s\S]*)%cayo\.title%/g, () => !head.includes('<title>') ? title() : '')
-        // .replace(/(?<!<!--[\s\S]*)%cayo\.head%/g, () => head)
-        // .replace(/(?<!<!--[\s\S]*)%cayo\.body%/g, () => html)
-        // .replace(/(?<!<!--[\s\S]*)%cayo\.css%/g, () => cssElements)
         // Vite needs the entry file in this format
-        .replace(/(?<!<!--[\s\S]*)%cayo\.script%/g, () => `<script type="module" src="./index.js"></script>`), 
+        .replace('%cayo.script%', () => `<script type="module" src="./index.js"></script>`), 
       css,
     }
   }

--- a/lib/core/render/renderer.js
+++ b/lib/core/render/renderer.js
@@ -37,9 +37,9 @@ export class Renderer {
     // https://stackoverflow.com/questions/9423722/string-replace-weird-behavior-when-using-dollar-sign-as-replacement
     return {
       html: this.template.html
-      // FIXME#83: this regex is bad; accidentally removes elements like head
-      // Ignore placeholders wrapped in HTML comments
-      // .replace(/<!--[^]*\%cayo\.\w+\%[^]*-->/g, '') 
+        // Ignore placeholders wrapped in HTML comments
+        .replace(/<!--\s*%cayo\.\w+%[\s\S]*-->/g, '')
+        // Inject markup in the cayo placeholders
         .replace('%cayo.title%', () => !head.includes('<title>') ? title() : '')
         .replace('%cayo.head%', () => head)
         .replace('%cayo.body%', () => html)

--- a/lib/core/render/renderer.js
+++ b/lib/core/render/renderer.js
@@ -38,14 +38,18 @@ export class Renderer {
     return {
       html: this.template.html
         // Ignore placeholders wrapped in HTML comments
-        .replace(/<!--\s*%cayo\.\w+%[\s\S]*-->/g, '')
+        .replace(/<!--\s*%cayo\.\w+%[\s\S]*?(-->)/g, '')
         // Inject markup in the cayo placeholders
         .replace('%cayo.title%', () => !head.includes('<title>') ? title() : '')
         .replace('%cayo.head%', () => head)
         .replace('%cayo.body%', () => html)
         .replace('%cayo.css%', () => cssElements)
+        // .replace(/(?<!<!--[\s\S]*)%cayo\.title%/g, () => !head.includes('<title>') ? title() : '')
+        // .replace(/(?<!<!--[\s\S]*)%cayo\.head%/g, () => head)
+        // .replace(/(?<!<!--[\s\S]*)%cayo\.body%/g, () => html)
+        // .replace(/(?<!<!--[\s\S]*)%cayo\.css%/g, () => cssElements)
         // Vite needs the entry file in this format
-        .replace('%cayo.script%', () => `<script type="module" src="./index.js"></script>`), 
+        .replace(/(?<!<!--[\s\S]*)%cayo\.script%/g, () => `<script type="module" src="./index.js"></script>`), 
       css,
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cayo",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cayo",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-json": "^4.1.0",
@@ -22,6 +22,7 @@
         "rollup-plugin-import-css": "^3.0.3",
         "rollup-plugin-svelte": "^7.1.0",
         "svelte": "^3.49.0",
+        "tosource": "^2.0.0-alpha.3",
         "vite": "^3.1.2",
         "yargs-parser": "^20.2.9",
         "zod": "^3.10.3"
@@ -42,9 +43,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.8.tgz",
-      "integrity": "sha512-CyEWALmn+no/lbgbAJsbuuhT8s2J19EJGHkeyAwjbFJMrj80KJ9zuYsoAvidPTU7BgBf87r/sgae8Tw0dbOc4Q==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
+      "integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
       "cpu": [
         "arm"
       ],
@@ -52,17 +53,14 @@
       "os": [
         "android"
       ],
-      "dependencies": {
-        "esbuild-wasm": "0.15.8"
-      },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.8.tgz",
-      "integrity": "sha512-pE5RQsOTSERCtfZdfCT25wzo7dfhOSlhAXcsZmuvRYhendOv7djcdvtINdnDp2DAjP17WXlBB4nBO6sHLczmsg==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
+      "integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
       "cpu": [
         "loong64"
       ],
@@ -696,9 +694,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.8.tgz",
-      "integrity": "sha512-Remsk2dmr1Ia65sU+QasE6svJbsHe62lzR+CnjpUvbZ+uSYo1SitiOWPRfZQkCu82YWZBBKXiD/j0i//XWMZ+Q==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
+      "integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -707,34 +705,34 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.15.8",
-        "@esbuild/linux-loong64": "0.15.8",
-        "esbuild-android-64": "0.15.8",
-        "esbuild-android-arm64": "0.15.8",
-        "esbuild-darwin-64": "0.15.8",
-        "esbuild-darwin-arm64": "0.15.8",
-        "esbuild-freebsd-64": "0.15.8",
-        "esbuild-freebsd-arm64": "0.15.8",
-        "esbuild-linux-32": "0.15.8",
-        "esbuild-linux-64": "0.15.8",
-        "esbuild-linux-arm": "0.15.8",
-        "esbuild-linux-arm64": "0.15.8",
-        "esbuild-linux-mips64le": "0.15.8",
-        "esbuild-linux-ppc64le": "0.15.8",
-        "esbuild-linux-riscv64": "0.15.8",
-        "esbuild-linux-s390x": "0.15.8",
-        "esbuild-netbsd-64": "0.15.8",
-        "esbuild-openbsd-64": "0.15.8",
-        "esbuild-sunos-64": "0.15.8",
-        "esbuild-windows-32": "0.15.8",
-        "esbuild-windows-64": "0.15.8",
-        "esbuild-windows-arm64": "0.15.8"
+        "@esbuild/android-arm": "0.15.18",
+        "@esbuild/linux-loong64": "0.15.18",
+        "esbuild-android-64": "0.15.18",
+        "esbuild-android-arm64": "0.15.18",
+        "esbuild-darwin-64": "0.15.18",
+        "esbuild-darwin-arm64": "0.15.18",
+        "esbuild-freebsd-64": "0.15.18",
+        "esbuild-freebsd-arm64": "0.15.18",
+        "esbuild-linux-32": "0.15.18",
+        "esbuild-linux-64": "0.15.18",
+        "esbuild-linux-arm": "0.15.18",
+        "esbuild-linux-arm64": "0.15.18",
+        "esbuild-linux-mips64le": "0.15.18",
+        "esbuild-linux-ppc64le": "0.15.18",
+        "esbuild-linux-riscv64": "0.15.18",
+        "esbuild-linux-s390x": "0.15.18",
+        "esbuild-netbsd-64": "0.15.18",
+        "esbuild-openbsd-64": "0.15.18",
+        "esbuild-sunos-64": "0.15.18",
+        "esbuild-windows-32": "0.15.18",
+        "esbuild-windows-64": "0.15.18",
+        "esbuild-windows-arm64": "0.15.18"
       }
     },
     "node_modules/esbuild-android-64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.8.tgz",
-      "integrity": "sha512-bVh8FIKOolF7/d4AMzt7xHlL0Ljr+mYKSHI39TJWDkybVWHdn6+4ODL3xZGHOxPpdRpitemXA1WwMKYBsw8dGw==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
+      "integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
       "cpu": [
         "x64"
       ],
@@ -742,17 +740,14 @@
       "os": [
         "android"
       ],
-      "dependencies": {
-        "esbuild-wasm": "0.15.8"
-      },
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/esbuild-android-arm64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.8.tgz",
-      "integrity": "sha512-ReAMDAHuo0H1h9LxRabI6gwYPn8k6WiUeyxuMvx17yTrJO+SCnIfNc/TSPFvDwtK9MiyiKG/2dBYHouT/M0BXQ==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
+      "integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
       "cpu": [
         "arm64"
       ],
@@ -765,9 +760,9 @@
       }
     },
     "node_modules/esbuild-darwin-64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.8.tgz",
-      "integrity": "sha512-KaKcGfJ+yto7Fo5gAj3xwxHMd1fBIKatpCHK8znTJLVv+9+NN2/tIPBqA4w5rBwjX0UqXDeIE2v1xJP+nGEXgA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
+      "integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
       "cpu": [
         "x64"
       ],
@@ -780,9 +775,9 @@
       }
     },
     "node_modules/esbuild-darwin-arm64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.8.tgz",
-      "integrity": "sha512-8tjEaBgAKnXCkP7bhEJmEqdG9HEV6oLkF36BrMzpfW2rgaw0c48Zrxe+9RlfeGvs6gDF4w+agXyTjikzsS3izw==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
+      "integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
       "cpu": [
         "arm64"
       ],
@@ -795,9 +790,9 @@
       }
     },
     "node_modules/esbuild-freebsd-64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.8.tgz",
-      "integrity": "sha512-jaxcsGHYzn2L0/lffON2WfH4Nc+d/EwozVTP5K2v016zxMb5UQMhLoJzvLgBqHT1SG0B/mO+a+THnJCMVg15zw==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
+      "integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
       "cpu": [
         "x64"
       ],
@@ -810,9 +805,9 @@
       }
     },
     "node_modules/esbuild-freebsd-arm64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.8.tgz",
-      "integrity": "sha512-2xp2UlljMvX8HExtcg7VHaeQk8OBU0CSl1j18B5CcZmSDkLF9p3utuMXIopG3a08fr9Hv+Dz6+seSXUow/G51w==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
+      "integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
       "cpu": [
         "arm64"
       ],
@@ -825,9 +820,9 @@
       }
     },
     "node_modules/esbuild-linux-32": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.8.tgz",
-      "integrity": "sha512-9u1E54BRz1FQMl86iaHK146+4ID2KYNxL3trLZT4QLLx3M7Q9n4lGG3lrzqUatGR2cKy8c33b0iaCzsItZWkFg==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
+      "integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
       "cpu": [
         "ia32"
       ],
@@ -840,9 +835,9 @@
       }
     },
     "node_modules/esbuild-linux-64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.8.tgz",
-      "integrity": "sha512-4HxrsN9eUzJXdVGMTYA5Xler82FuZUu21bXKN42zcLHHNKCAMPUzD62I+GwDhsdgUBAUj0tRXDdsQHgaP6v0HA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
+      "integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
       "cpu": [
         "x64"
       ],
@@ -855,9 +850,9 @@
       }
     },
     "node_modules/esbuild-linux-arm": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.8.tgz",
-      "integrity": "sha512-7DVBU9SFjX4+vBwt8tHsUCbE6Vvl6y6FQWHAgyw1lybC5gULqn/WnjHYHN2/LJaZRsDBvxWT4msEgwLGq1Wd3Q==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
+      "integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
       "cpu": [
         "arm"
       ],
@@ -870,9 +865,9 @@
       }
     },
     "node_modules/esbuild-linux-arm64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.8.tgz",
-      "integrity": "sha512-1OCm7Aq0tEJT70PbxmHSGYDLYP8DKH8r4Nk7/XbVzWaduo9beCjGBB+tGZIHK6DdTQ3h00/4Tb/70YMH/bOtKg==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
+      "integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
       "cpu": [
         "arm64"
       ],
@@ -885,9 +880,9 @@
       }
     },
     "node_modules/esbuild-linux-mips64le": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.8.tgz",
-      "integrity": "sha512-yeFoNPVFPEzZvFYBfUQNG2TjGRaCyV1E27OcOg4LOtnGrxb2wA+mkW3luckyv1CEyd00mpAg7UdHx8nlx3ghgA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
+      "integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
       "cpu": [
         "mips64el"
       ],
@@ -900,9 +895,9 @@
       }
     },
     "node_modules/esbuild-linux-ppc64le": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.8.tgz",
-      "integrity": "sha512-CEyMMUUNabXibw8OSNmBXhOIGhnjNVl5Lpseiuf00iKN0V47oqDrbo4dsHz1wH62m49AR8iG8wpDlTqfYgKbtg==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
+      "integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
       "cpu": [
         "ppc64"
       ],
@@ -915,9 +910,9 @@
       }
     },
     "node_modules/esbuild-linux-riscv64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.8.tgz",
-      "integrity": "sha512-OCGSOaspMUjexSCU8ZiA0UnV/NiRU+s2vIfEcAQWQ6u32R+2luyfh/4ZaY6jFbylJE07Esc/yRvb9Q5fXuClXA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
+      "integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
       "cpu": [
         "riscv64"
       ],
@@ -930,9 +925,9 @@
       }
     },
     "node_modules/esbuild-linux-s390x": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.8.tgz",
-      "integrity": "sha512-RHdpdfxRTSrZXZJlFSLazFU4YwXLB5Rgf6Zr5rffqSsO4y9JybgtKO38bFwxZNlDXliYISXN/YROKrG9s7mZQA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
+      "integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
       "cpu": [
         "s390x"
       ],
@@ -945,9 +940,9 @@
       }
     },
     "node_modules/esbuild-netbsd-64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.8.tgz",
-      "integrity": "sha512-VolFFRatBH09T5QMWhiohAWCOien1R1Uz9K0BRVVTBgBaVBt7eArsXTKxVhUgRf2vwu2c2SXkuP0r7HLG0eozw==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
+      "integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
       "cpu": [
         "x64"
       ],
@@ -960,9 +955,9 @@
       }
     },
     "node_modules/esbuild-openbsd-64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.8.tgz",
-      "integrity": "sha512-HTAPlg+n4kUeE/isQxlCfsOz0xJGNoT5LJ9oYZWFKABfVf4Ycu7Zlf5ITgOnrdheTkz8JeL/gISIOCFAoOXrSA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
+      "integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
       "cpu": [
         "x64"
       ],
@@ -975,9 +970,9 @@
       }
     },
     "node_modules/esbuild-sunos-64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.8.tgz",
-      "integrity": "sha512-qMP/jR/FzcIOwKj+W+Lb+8Cfr8GZHbHUJxAPi7DUhNZMQ/6y7sOgRzlOSpRrbbUntrRZh0MqOyDhJ3Gpo6L1QA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
+      "integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
       "cpu": [
         "x64"
       ],
@@ -989,22 +984,10 @@
         "node": ">=12"
       }
     },
-    "node_modules/esbuild-wasm": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.15.8.tgz",
-      "integrity": "sha512-Y7uCl5RNO4URjlemjdx++ukVHEMt5s5AfMWYUnMiK4Sry+pPCvQIctzXq6r6FKCyGKjX6/NGMCqR2OX6aLxj0w==",
-      "optional": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/esbuild-windows-32": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.8.tgz",
-      "integrity": "sha512-RKR1QHh4iWzjUhkP8Yqi75PPz/KS+b8zw3wUrzw6oAkj+iU5Qtyj61ZDaSG3Qf2vc6hTIUiPqVTqBH0NpXFNwg==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
+      "integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
       "cpu": [
         "ia32"
       ],
@@ -1017,9 +1000,9 @@
       }
     },
     "node_modules/esbuild-windows-64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.8.tgz",
-      "integrity": "sha512-ag9ptYrsizgsR+PQE8QKeMqnosLvAMonQREpLw4evA4FFgOBMLEat/dY/9txbpozTw9eEOYyD3a4cE9yTu20FA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
+      "integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
       "cpu": [
         "x64"
       ],
@@ -1032,9 +1015,9 @@
       }
     },
     "node_modules/esbuild-windows-arm64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.8.tgz",
-      "integrity": "sha512-dbpAb0VyPaUs9mgw65KRfQ9rqiWCHpNzrJusoPu+LpEoswosjt/tFxN7cd2l68AT4qWdBkzAjDLRon7uqMeWcg==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
+      "integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
       "cpu": [
         "arm64"
       ],
@@ -1588,9 +1571,15 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -1673,9 +1662,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "version": "8.4.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
+      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
       "funding": [
         {
           "type": "opencollective",
@@ -1684,10 +1673,14 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -1853,9 +1846,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.78.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
-      "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -2006,6 +1999,14 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tosource": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/tosource/-/tosource-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-KAB2lrSS48y91MzFPFuDg4hLbvDiyTjOVgaK7Erw+5AmZXNq4sFRVn8r6yxSLuNs15PaokrDRpS61ERY9uZOug==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
@@ -2089,14 +2090,14 @@
       }
     },
     "node_modules/vite": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.2.tgz",
-      "integrity": "sha512-wTDKPkiVbeT+drTPdkuvjVIC/2vKKUc1w3qNOuwgpyvPCZF6fvdxB5v5WEcCsqaYea0zrwA4+XialJKCHM3oVQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.7.tgz",
+      "integrity": "sha512-29pdXjk49xAP0QBr0xXqu2s5jiQIXNvE/xwd0vUizYT2Hzqe4BksNNoWllFVXJf4eLZ+UlVQmXfB4lWrc+t18g==",
       "dependencies": {
-        "esbuild": "^0.15.6",
-        "postcss": "^8.4.16",
+        "esbuild": "^0.15.9",
+        "postcss": "^8.4.18",
         "resolve": "^1.22.1",
-        "rollup": "~2.78.0"
+        "rollup": "^2.79.1"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -2108,12 +2109,17 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
+        "@types/node": ">= 14",
         "less": "*",
         "sass": "*",
         "stylus": "*",
+        "sugarss": "*",
         "terser": "^5.4.0"
       },
       "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
         "less": {
           "optional": true
         },
@@ -2121,6 +2127,9 @@
           "optional": true
         },
         "stylus": {
+          "optional": true
+        },
+        "sugarss": {
           "optional": true
         },
         "terser": {
@@ -2247,18 +2256,15 @@
       "integrity": "sha512-syoCQFOoo/fzkWDeM0dLEZi5xqurb5vuyzwIMNZRNun+N/9A4cUZeQaE7dTrB8jGaKuJRBtEOajtnmw0I5hvvA=="
     },
     "@esbuild/android-arm": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.8.tgz",
-      "integrity": "sha512-CyEWALmn+no/lbgbAJsbuuhT8s2J19EJGHkeyAwjbFJMrj80KJ9zuYsoAvidPTU7BgBf87r/sgae8Tw0dbOc4Q==",
-      "optional": true,
-      "requires": {
-        "esbuild-wasm": "0.15.8"
-      }
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
+      "integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
+      "optional": true
     },
     "@esbuild/linux-loong64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.8.tgz",
-      "integrity": "sha512-pE5RQsOTSERCtfZdfCT25wzo7dfhOSlhAXcsZmuvRYhendOv7djcdvtINdnDp2DAjP17WXlBB4nBO6sHLczmsg==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
+      "integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -2723,161 +2729,152 @@
       }
     },
     "esbuild": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.8.tgz",
-      "integrity": "sha512-Remsk2dmr1Ia65sU+QasE6svJbsHe62lzR+CnjpUvbZ+uSYo1SitiOWPRfZQkCu82YWZBBKXiD/j0i//XWMZ+Q==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
+      "integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
       "requires": {
-        "@esbuild/android-arm": "0.15.8",
-        "@esbuild/linux-loong64": "0.15.8",
-        "esbuild-android-64": "0.15.8",
-        "esbuild-android-arm64": "0.15.8",
-        "esbuild-darwin-64": "0.15.8",
-        "esbuild-darwin-arm64": "0.15.8",
-        "esbuild-freebsd-64": "0.15.8",
-        "esbuild-freebsd-arm64": "0.15.8",
-        "esbuild-linux-32": "0.15.8",
-        "esbuild-linux-64": "0.15.8",
-        "esbuild-linux-arm": "0.15.8",
-        "esbuild-linux-arm64": "0.15.8",
-        "esbuild-linux-mips64le": "0.15.8",
-        "esbuild-linux-ppc64le": "0.15.8",
-        "esbuild-linux-riscv64": "0.15.8",
-        "esbuild-linux-s390x": "0.15.8",
-        "esbuild-netbsd-64": "0.15.8",
-        "esbuild-openbsd-64": "0.15.8",
-        "esbuild-sunos-64": "0.15.8",
-        "esbuild-windows-32": "0.15.8",
-        "esbuild-windows-64": "0.15.8",
-        "esbuild-windows-arm64": "0.15.8"
+        "@esbuild/android-arm": "0.15.18",
+        "@esbuild/linux-loong64": "0.15.18",
+        "esbuild-android-64": "0.15.18",
+        "esbuild-android-arm64": "0.15.18",
+        "esbuild-darwin-64": "0.15.18",
+        "esbuild-darwin-arm64": "0.15.18",
+        "esbuild-freebsd-64": "0.15.18",
+        "esbuild-freebsd-arm64": "0.15.18",
+        "esbuild-linux-32": "0.15.18",
+        "esbuild-linux-64": "0.15.18",
+        "esbuild-linux-arm": "0.15.18",
+        "esbuild-linux-arm64": "0.15.18",
+        "esbuild-linux-mips64le": "0.15.18",
+        "esbuild-linux-ppc64le": "0.15.18",
+        "esbuild-linux-riscv64": "0.15.18",
+        "esbuild-linux-s390x": "0.15.18",
+        "esbuild-netbsd-64": "0.15.18",
+        "esbuild-openbsd-64": "0.15.18",
+        "esbuild-sunos-64": "0.15.18",
+        "esbuild-windows-32": "0.15.18",
+        "esbuild-windows-64": "0.15.18",
+        "esbuild-windows-arm64": "0.15.18"
       }
     },
     "esbuild-android-64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.8.tgz",
-      "integrity": "sha512-bVh8FIKOolF7/d4AMzt7xHlL0Ljr+mYKSHI39TJWDkybVWHdn6+4ODL3xZGHOxPpdRpitemXA1WwMKYBsw8dGw==",
-      "optional": true,
-      "requires": {
-        "esbuild-wasm": "0.15.8"
-      }
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
+      "integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
+      "optional": true
     },
     "esbuild-android-arm64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.8.tgz",
-      "integrity": "sha512-ReAMDAHuo0H1h9LxRabI6gwYPn8k6WiUeyxuMvx17yTrJO+SCnIfNc/TSPFvDwtK9MiyiKG/2dBYHouT/M0BXQ==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
+      "integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
       "optional": true
     },
     "esbuild-darwin-64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.8.tgz",
-      "integrity": "sha512-KaKcGfJ+yto7Fo5gAj3xwxHMd1fBIKatpCHK8znTJLVv+9+NN2/tIPBqA4w5rBwjX0UqXDeIE2v1xJP+nGEXgA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
+      "integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
       "optional": true
     },
     "esbuild-darwin-arm64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.8.tgz",
-      "integrity": "sha512-8tjEaBgAKnXCkP7bhEJmEqdG9HEV6oLkF36BrMzpfW2rgaw0c48Zrxe+9RlfeGvs6gDF4w+agXyTjikzsS3izw==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
+      "integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
       "optional": true
     },
     "esbuild-freebsd-64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.8.tgz",
-      "integrity": "sha512-jaxcsGHYzn2L0/lffON2WfH4Nc+d/EwozVTP5K2v016zxMb5UQMhLoJzvLgBqHT1SG0B/mO+a+THnJCMVg15zw==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
+      "integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
       "optional": true
     },
     "esbuild-freebsd-arm64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.8.tgz",
-      "integrity": "sha512-2xp2UlljMvX8HExtcg7VHaeQk8OBU0CSl1j18B5CcZmSDkLF9p3utuMXIopG3a08fr9Hv+Dz6+seSXUow/G51w==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
+      "integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
       "optional": true
     },
     "esbuild-linux-32": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.8.tgz",
-      "integrity": "sha512-9u1E54BRz1FQMl86iaHK146+4ID2KYNxL3trLZT4QLLx3M7Q9n4lGG3lrzqUatGR2cKy8c33b0iaCzsItZWkFg==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
+      "integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
       "optional": true
     },
     "esbuild-linux-64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.8.tgz",
-      "integrity": "sha512-4HxrsN9eUzJXdVGMTYA5Xler82FuZUu21bXKN42zcLHHNKCAMPUzD62I+GwDhsdgUBAUj0tRXDdsQHgaP6v0HA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
+      "integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
       "optional": true
     },
     "esbuild-linux-arm": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.8.tgz",
-      "integrity": "sha512-7DVBU9SFjX4+vBwt8tHsUCbE6Vvl6y6FQWHAgyw1lybC5gULqn/WnjHYHN2/LJaZRsDBvxWT4msEgwLGq1Wd3Q==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
+      "integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
       "optional": true
     },
     "esbuild-linux-arm64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.8.tgz",
-      "integrity": "sha512-1OCm7Aq0tEJT70PbxmHSGYDLYP8DKH8r4Nk7/XbVzWaduo9beCjGBB+tGZIHK6DdTQ3h00/4Tb/70YMH/bOtKg==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
+      "integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
       "optional": true
     },
     "esbuild-linux-mips64le": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.8.tgz",
-      "integrity": "sha512-yeFoNPVFPEzZvFYBfUQNG2TjGRaCyV1E27OcOg4LOtnGrxb2wA+mkW3luckyv1CEyd00mpAg7UdHx8nlx3ghgA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
+      "integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
       "optional": true
     },
     "esbuild-linux-ppc64le": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.8.tgz",
-      "integrity": "sha512-CEyMMUUNabXibw8OSNmBXhOIGhnjNVl5Lpseiuf00iKN0V47oqDrbo4dsHz1wH62m49AR8iG8wpDlTqfYgKbtg==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
+      "integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
       "optional": true
     },
     "esbuild-linux-riscv64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.8.tgz",
-      "integrity": "sha512-OCGSOaspMUjexSCU8ZiA0UnV/NiRU+s2vIfEcAQWQ6u32R+2luyfh/4ZaY6jFbylJE07Esc/yRvb9Q5fXuClXA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
+      "integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
       "optional": true
     },
     "esbuild-linux-s390x": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.8.tgz",
-      "integrity": "sha512-RHdpdfxRTSrZXZJlFSLazFU4YwXLB5Rgf6Zr5rffqSsO4y9JybgtKO38bFwxZNlDXliYISXN/YROKrG9s7mZQA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
+      "integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
       "optional": true
     },
     "esbuild-netbsd-64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.8.tgz",
-      "integrity": "sha512-VolFFRatBH09T5QMWhiohAWCOien1R1Uz9K0BRVVTBgBaVBt7eArsXTKxVhUgRf2vwu2c2SXkuP0r7HLG0eozw==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
+      "integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
       "optional": true
     },
     "esbuild-openbsd-64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.8.tgz",
-      "integrity": "sha512-HTAPlg+n4kUeE/isQxlCfsOz0xJGNoT5LJ9oYZWFKABfVf4Ycu7Zlf5ITgOnrdheTkz8JeL/gISIOCFAoOXrSA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
+      "integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
       "optional": true
     },
     "esbuild-sunos-64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.8.tgz",
-      "integrity": "sha512-qMP/jR/FzcIOwKj+W+Lb+8Cfr8GZHbHUJxAPi7DUhNZMQ/6y7sOgRzlOSpRrbbUntrRZh0MqOyDhJ3Gpo6L1QA==",
-      "optional": true
-    },
-    "esbuild-wasm": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-wasm/-/esbuild-wasm-0.15.8.tgz",
-      "integrity": "sha512-Y7uCl5RNO4URjlemjdx++ukVHEMt5s5AfMWYUnMiK4Sry+pPCvQIctzXq6r6FKCyGKjX6/NGMCqR2OX6aLxj0w==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
+      "integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
       "optional": true
     },
     "esbuild-windows-32": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.8.tgz",
-      "integrity": "sha512-RKR1QHh4iWzjUhkP8Yqi75PPz/KS+b8zw3wUrzw6oAkj+iU5Qtyj61ZDaSG3Qf2vc6hTIUiPqVTqBH0NpXFNwg==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
+      "integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
       "optional": true
     },
     "esbuild-windows-64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.8.tgz",
-      "integrity": "sha512-ag9ptYrsizgsR+PQE8QKeMqnosLvAMonQREpLw4evA4FFgOBMLEat/dY/9txbpozTw9eEOYyD3a4cE9yTu20FA==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
+      "integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
       "optional": true
     },
     "esbuild-windows-arm64": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.8.tgz",
-      "integrity": "sha512-dbpAb0VyPaUs9mgw65KRfQ9rqiWCHpNzrJusoPu+LpEoswosjt/tFxN7cd2l68AT4qWdBkzAjDLRon7uqMeWcg==",
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
+      "integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
       "optional": true
     },
     "escape-string-regexp": {
@@ -3266,9 +3263,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "nanoid": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
+      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
     },
     "node-source-walk": {
       "version": "4.2.0",
@@ -3327,11 +3324,11 @@
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
     },
     "postcss": {
-      "version": "8.4.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
-      "integrity": "sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==",
+      "version": "8.4.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
+      "integrity": "sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==",
       "requires": {
-        "nanoid": "^3.3.4",
+        "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       }
@@ -3441,9 +3438,9 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
     },
     "rollup": {
-      "version": "2.78.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
-      "integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -3542,6 +3539,11 @@
         "is-number": "^7.0.0"
       }
     },
+    "tosource": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/tosource/-/tosource-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-KAB2lrSS48y91MzFPFuDg4hLbvDiyTjOVgaK7Erw+5AmZXNq4sFRVn8r6yxSLuNs15PaokrDRpS61ERY9uZOug=="
+    },
     "tough-cookie": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
@@ -3599,15 +3601,15 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "vite": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-3.1.2.tgz",
-      "integrity": "sha512-wTDKPkiVbeT+drTPdkuvjVIC/2vKKUc1w3qNOuwgpyvPCZF6fvdxB5v5WEcCsqaYea0zrwA4+XialJKCHM3oVQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-3.2.7.tgz",
+      "integrity": "sha512-29pdXjk49xAP0QBr0xXqu2s5jiQIXNvE/xwd0vUizYT2Hzqe4BksNNoWllFVXJf4eLZ+UlVQmXfB4lWrc+t18g==",
       "requires": {
-        "esbuild": "^0.15.6",
+        "esbuild": "^0.15.9",
         "fsevents": "~2.3.2",
-        "postcss": "^8.4.16",
+        "postcss": "^8.4.18",
         "resolve": "^1.22.1",
-        "rollup": "~2.78.0"
+        "rollup": "^2.79.1"
       }
     },
     "w3c-hr-time": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cayo",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "start": "node cayo dev --projectRoot test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cayo",
-  "version": "1.2.1",
+  "version": "1.2.0",
   "type": "module",
   "scripts": {
     "start": "node cayo dev --projectRoot test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cayo",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "type": "module",
   "scripts": {
     "start": "node cayo dev --projectRoot test",
@@ -43,6 +43,7 @@
     "rollup-plugin-import-css": "^3.0.3",
     "rollup-plugin-svelte": "^7.1.0",
     "svelte": "^3.49.0",
+    "tosource": "^2.0.0-alpha.3",
     "vite": "^3.1.2",
     "yargs-parser": "^20.2.9",
     "zod": "^3.10.3"

--- a/src/cayo.svelte
+++ b/src/cayo.svelte
@@ -18,23 +18,24 @@
     return value;
   };
 
-  const json = JSON.stringify({...$$restProps}, replacer);
+  // const props = toSource({...$$restProps})
+  const props = JSON.stringify({...$$restProps}, replacer);
   const warnings = getWarnings(src, badProps);
   const cayoInstanceData = {
-    'data-cayo-id': '',
     'data-cayo-src': !warnings.invalidSrc ? `${src}` : '',  
-    'data-cayo-props': json,
+    'data-cayo-id': '', // will get set during prerender process based on the src
   };
   if (warnings) {
     cayoInstanceData['data-cayo-warn'] = JSON.stringify(warnings);
   }
 </script>
+
 <div 
   data-cayo-id={cayoInstanceData['data-cayo-id']}
   data-cayo-src={cayoInstanceData['data-cayo-src']}
-  data-cayo-props={cayoInstanceData['data-cayo-props']}
   data-cayo-warn={cayoInstanceData['data-cayo-warn']}
 >
+  {@html `<script data-cayo-props type="application/json">${props}</script>`}
   <slot/>
 </div>
 


### PR DESCRIPTION
### Fix Template

A series of fixes related to the template file and how it was prerendered:
- HTML Comments are now stripped from the Template. Previously, this caused issues where commented placeholders would still match and cayo would still inject code into the comments.
- Doctype element now works correctly. Previously, when not included in the template, it would still render in the output.

### Fix Props Storage: Prevent Svelte from needing to HTML-encode props

Previously, cayo injected the props as JSON into a data attribute on a Cayo's container element. Svelte encodes data attributes in order to output valid HTML, and prevent errors like nested quotes breaking the data attribute value. E.g., it would output HTML like this:

```html
<div data-cayo-props='{key="&apos;quoted string value&apos;}'>
```

where the actual JSON would just be:
```json
{"key": "'quoted string value'"}
```

Those `&apos;` are HTML entities for `'` characters. This made the HTML output valid, but caused downstream effects when trying to hydrate a Cayo with that html-encoded string. 

This fix changes the way cayo stores the props. Rather than storing in a data attribute, it temporarily stores it as JSON in a script element, like so:

Source code (Svelte)
```svelte

<script>
  // ...
  const data = {
    key: "'quoted string value'";
  }
</script>
<Cayo src="foo.cayo.svelte" {data} />
```

Prerendered output HTML:
```html
<div data-cayo-id="...">
  <script data-cayo-props type="application/json">
    {data: {"key": "'quoted string value'"}}
  </script>
</div>
```

Cayo still reads that JSON string from the markup during hydration, just from the `script[data=cayo-props].innerHTML` instead of a data attribute's value (this happens in `cayo-runtime.js`, generated by `codegen.js`).
