### PR TITLE
feat: change the expected template strings to use Svelte "<template>"…

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,20 +143,23 @@ The Template file is required, and used to render all of your pages. The output 
 
 This file is a Svelte component, so you can also import other Svelte components or add rendering logic. For example, you could render different markup wrapping your pages depending on the environment mode like `'development'` or `'production'` (see [config example](docs//config-reference.md#conditional-config)).
 
+> **Deprecation Notice**<br>
+> The `%cayo.*%` placeholder syntax is deprecated as of v1.4.0. Please migrate to the new `<template cayo="...">` syntax. The old syntax will continue to work for backward compatibility but may break in future Svelte versions. See [migration guide](#template-placeholder-migration) below.
+
 > **Note**<br>
-> Despite being a Svelte component, the Template file does not support the `<slot>` element, because it itself is prerendered _before_ it is used to prerender page components. The placeholder `%cayo.body%` replaces the basic usage for `<slot>`.
+> Despite being a Svelte component, the Template file does not support the `<slot>` element, because it itself is prerendered _before_ it is used to prerender page components. The placeholder `<template cayo="body">` replaces the basic usage for `<slot>`.
 
 Template files support the following placeholders:
 
-- `%cayo.body%` – the content of a page. Think of this as the `<slot>` of the Template Svelte component
+- `<template cayo="body">` – the content of a page. Think of this as the `<slot>` of the Template Svelte component
 
-- `%cayo.script%` – where your [entry](#entries) for a page will be imported. This is needed if a page is to render a Cayo Component, but is otherwise optional
+- `<template cayo="script">` – where your [entry](#entries) for a page will be imported. This is needed if a page is to render a Cayo Component, but is otherwise optional
 
-- `%cayo.css%` – where CSS will be added (as `<link src="style.css">` or `<style>...</style>` depending on your [CSS config option](docs/config-reference.md#cssinternal))
+- `<template cayo="css">` – where CSS will be added (as `<link src="style.css">` or `<style>...</style>` depending on your [CSS config option](docs/config-reference.md#cssinternal))
 
-- `%cayo.title%` – add a default title to the page only if one is not already set on a specific page (via [`<svelte:head>`](https://svelte.dev/docs#template-syntax-svelte-head) or other some other method). The default title will be generated using the page's filename (e.g., `page.svelte` will have the title `Page`). This placeholder is optional
+- `<template cayo="title">` – add a default title to the page only if one is not already set on a specific page (via [`<svelte:head>`](https://svelte.dev/docs#template-syntax-svelte-head) or other some other method). The default title will be generated using the page's filename (e.g., `page.svelte` will have the title `Page`). This placeholder is optional
 
-- `%cayo.head%` – `<link>` and `<script>` elements needed by a page, plus any `<svelte:head>` content
+- `<template cayo="head">` – `<link>` and `<script>` elements needed by a page, plus any `<svelte:head>` content
 
 #### Example
 Technically all of the placeholders are optional, and don't have to be in any particular place within your markup.
@@ -166,13 +169,13 @@ Technically all of the placeholders are optional, and don't have to be in any pa
 <!DOCTYPE html>
 <html>
   <head>
-    %cayo.head%
-    %cayo.title%
-    %cayo.css%    
+    <template cayo="head"></template>
+    <template cayo="title"></template>
+    <template cayo="css"></template>    
   </head>
   <body>
-    %cayo.body%
-    %cayo.script%
+    <template cayo="body"></template>
+    <template cayo="script"></template>
   </body>
 </html>
 ```
@@ -183,10 +186,34 @@ Your template doesn't even need to be a valid HTML document—you could be outpu
 <!-- src/__template.svelte -->
 <!-- No html, head, or body elements... and that's okay! -->
 <div>something I want on every page</div>
-%cayo.script%
+<template cayo="script"></template>
+<template cayo="css"></template>
+<template cayo="body"></template>
+```
+
+#### Template Placeholder Migration
+
+If you're upgrading from an older version that used `%cayo.*%` syntax, here's how to migrate to the new `<template cayo="...">` syntax:
+
+**Old syntax (deprecated):**
+```html
+%cayo.title%
+%cayo.head%
 %cayo.css%
 %cayo.body%
+%cayo.script%
 ```
+
+**New syntax (recommended):**
+```html
+<template cayo="title"></template>
+<template cayo="head"></template>
+<template cayo="css"></template>
+<template cayo="body"></template>
+<template cayo="script"></template>
+```
+
+The new template syntax supports content inside the tags (which will be replaced), while the old syntax only supported exact placeholder matching. Both syntaxes will continue to work, but the old syntax is deprecated and may break in future Svelte versions.
 
 ### .cayo
 

--- a/README.md
+++ b/README.md
@@ -143,23 +143,23 @@ The Template file is required, and used to render all of your pages. The output 
 
 This file is a Svelte component, so you can also import other Svelte components or add rendering logic. For example, you could render different markup wrapping your pages depending on the environment mode like `'development'` or `'production'` (see [config example](docs//config-reference.md#conditional-config)).
 
-> **Deprecation Notice**<br>
-> The `%cayo.*%` placeholder syntax is deprecated as of v1.4.0. Please migrate to the new `<template cayo="...">` syntax. The old syntax will continue to work for backward compatibility but may break in future Svelte versions. See [migration guide](#template-placeholder-migration) below.
+> **Template Placeholder Syntax**<br>
+> Cayo uses HTML comment placeholders: `<!--[cayo-css]-->` for template injection. The `%cayo.*%` syntax is deprecated. See [placeholder syntax guide](#template-placeholder-syntax) below.
 
 > **Note**<br>
-> Despite being a Svelte component, the Template file does not support the `<slot>` element, because it itself is prerendered _before_ it is used to prerender page components. The placeholder `<template cayo="body">` replaces the basic usage for `<slot>`.
+> Despite being a Svelte component, the Template file does not support the `<slot>` element, because it itself is prerendered _before_ it is used to prerender page components. The placeholder `<!--[cayo-body]-->` replaces the basic usage for `<slot>`.
 
 Template files support the following placeholders:
 
-- `<template cayo="body">` – the content of a page. Think of this as the `<slot>` of the Template Svelte component
+- `<!--[cayo-body]-->` – the content of a page. Think of this as the `<slot>` of the Template Svelte component
 
-- `<template cayo="script">` – where your [entry](#entries) for a page will be imported. This is needed if a page is to render a Cayo Component, but is otherwise optional
+- `<!--[cayo-script]-->` – where your [entry](#entries) for a page will be imported. This is needed if a page is to render a Cayo Component, but is otherwise optional
 
-- `<template cayo="css">` – where CSS will be added (as `<link src="style.css">` or `<style>...</style>` depending on your [CSS config option](docs/config-reference.md#cssinternal))
+- `<!--[cayo-css]-->` – where CSS will be added (as `<link src="style.css">` or `<style>...</style>` depending on your [CSS config option](docs/config-reference.md#cssinternal))
 
-- `<template cayo="title">` – add a default title to the page only if one is not already set on a specific page (via [`<svelte:head>`](https://svelte.dev/docs#template-syntax-svelte-head) or other some other method). The default title will be generated using the page's filename (e.g., `page.svelte` will have the title `Page`). This placeholder is optional
+- `<!--[cayo-title]-->` – add a default title to the page only if one is not already set on a specific page (via [`<svelte:head>`](https://svelte.dev/docs#template-syntax-svelte-head) or other some other method). The default title will be generated using the page's filename (e.g., `page.svelte` will have the title `Page`). This placeholder is optional
 
-- `<template cayo="head">` – `<link>` and `<script>` elements needed by a page, plus any `<svelte:head>` content
+- `<!--[cayo-head]-->` – `<link>` and `<script>` elements needed by a page, plus any `<svelte:head>` content
 
 #### Example
 Technically all of the placeholders are optional, and don't have to be in any particular place within your markup.
@@ -169,13 +169,13 @@ Technically all of the placeholders are optional, and don't have to be in any pa
 <!DOCTYPE html>
 <html>
   <head>
-    <template cayo="head"></template>
-    <template cayo="title"></template>
-    <template cayo="css"></template>    
+    <!--[cayo-head]-->
+    <!--[cayo-title]-->
+    <!--[cayo-css]-->    
   </head>
   <body>
-    <template cayo="body"></template>
-    <template cayo="script"></template>
+    <!--[cayo-body]-->
+    <!--[cayo-script]-->
   </body>
 </html>
 ```
@@ -186,16 +186,25 @@ Your template doesn't even need to be a valid HTML document—you could be outpu
 <!-- src/__template.svelte -->
 <!-- No html, head, or body elements... and that's okay! -->
 <div>something I want on every page</div>
-<template cayo="script"></template>
-<template cayo="css"></template>
-<template cayo="body"></template>
+<!--[cayo-script]-->
+<!--[cayo-css]-->
+<!--[cayo-body]-->
 ```
 
-#### Template Placeholder Migration
+#### Template Placeholder Syntax
 
-If you're upgrading from an older version that used `%cayo.*%` syntax, here's how to migrate to the new `<template cayo="...">` syntax:
+Cayo supports the following placeholder syntaxes:
 
-**Old syntax (deprecated):**
+**Recommended syntax (HTML comments):**
+```html
+<!--[cayo-title]-->
+<!--[cayo-head]-->
+<!--[cayo-css]-->
+<!--[cayo-body]-->
+<!--[cayo-script]-->
+```
+
+**Deprecated syntax:**
 ```html
 %cayo.title%
 %cayo.head%
@@ -204,16 +213,7 @@ If you're upgrading from an older version that used `%cayo.*%` syntax, here's ho
 %cayo.script%
 ```
 
-**New syntax (recommended):**
-```html
-<template cayo="title"></template>
-<template cayo="head"></template>
-<template cayo="css"></template>
-<template cayo="body"></template>
-<template cayo="script"></template>
-```
-
-The new template syntax supports content inside the tags (which will be replaced), while the old syntax only supported exact placeholder matching. Both syntaxes will continue to work, but the old syntax is deprecated and may break in future Svelte versions.
+The HTML comment syntax is reliable since Svelte always preserves comments during SSR compilation. The `%cayo.*%` syntax is deprecated but still supported for backward compatibility.
 
 ### .cayo
 

--- a/lib/core/bundle.js
+++ b/lib/core/bundle.js
@@ -9,6 +9,7 @@ import json from '@rollup/plugin-json';
 function inputOptions(input) {
   return { 
     input,
+    external: (id) => id === 'svelte' || id.startsWith('svelte/'),
     onwarn: function ( message ) {
       if ( /external dependency/.test( message ) ) return;
     },

--- a/lib/core/bundle.js
+++ b/lib/core/bundle.js
@@ -105,16 +105,26 @@ export async function getDeps(input, config) {
 }
 
 export async function build(input, config, type = 'page') {
-  const template = (type === 'page' || type === 'template');
+  const ssr = (type === 'page' || type === 'template');
   const isCayo = (type === 'cayo');
   const requiredCompilerOptions = {
-    generate: template ? 'ssr' : 'dom', 
-    hydratable: template ? false : true, 
-    preserveComments: template 
-      ? false
-      : config.svelte.compilerOptions.preserveComments
-        ? config.svelte.compilerOptions.preserveComments
-        : true,
+    // Generic defaults for all builds
+    preserveWhitespace: true,
+  }
+
+  if (ssr) {
+    // Pages & Templates (SSR): server-side rendered
+    requiredCompilerOptions.generate = 'ssr';
+    requiredCompilerOptions.hydratable = false;
+    
+    if (type === 'template') {
+      // Templates need comments preserved for Cayo placeholders
+      requiredCompilerOptions.preserveComments = true;
+    }
+  } else {
+    // Cayo Components (DOM): client-side hydration
+    requiredCompilerOptions.generate = 'dom';
+    requiredCompilerOptions.hydratable = true;
   }
 
   let bundle;

--- a/lib/core/bundle.js
+++ b/lib/core/bundle.js
@@ -36,7 +36,13 @@ function sveltePluginDefaults() {
 }
 
 function defaultRollupPlugins() {
-  return [commonjs(), css(), json()];
+  return [
+    commonjs({
+      include: /node_modules/,
+    }), 
+    css(), 
+    json()
+  ];
 }
 
 function userRollupPlugins(config) {

--- a/lib/core/render/prerender.js
+++ b/lib/core/render/prerender.js
@@ -123,7 +123,7 @@ export async function processPage(content, page, _cayo, logger) {
   } else {
     if (cayoAssetCssElements) {
       logger.log.info(
-        chalk.yellow.bold('Warning') + chalk.yellow(': No %cayo.css% found in template, but there is CSS used in source files.'),
+        chalk.yellow.bold('Warning') + chalk.yellow(': No <template cayo="css"> found in template, but there is CSS used in source files.'),
         { timestamp: true, clear: false, }
       );
     }

--- a/lib/core/render/renderer.js
+++ b/lib/core/render/renderer.js
@@ -1,3 +1,6 @@
+import logger from '../logger.js';
+import chalk from 'chalk';
+
 export class Renderer {
 
   constructor(template) {
@@ -35,17 +38,31 @@ export class Renderer {
     // Note: Q: why the `() => str` for 2nd replacement arg?
     //       A: In case there's dollar signs in that there string
     // https://stackoverflow.com/questions/9423722/string-replace-weird-behavior-when-using-dollar-sign-as-replacement
+    // Check for deprecated %cayo.*% syntax and log deprecation warnings
+    const deprecatedPlaceholders = this.template.html.match(/%cayo\.[a-zA-Z]+%/g);
+    if (deprecatedPlaceholders) {
+      logger.log.info(
+        chalk.yellow.bold('Deprecation Warning') + chalk.yellow(': Found deprecated %cayo.*% placeholder syntax. Please migrate to <template cayo="..."> syntax. The old syntax will continue to work but may break in future Svelte versions.'),
+        { timestamp: true, clear: false }
+      );
+    }
+
     return {
       html: this.template.html
         // Strip placeholders wrapped in HTML comments
         .replace(/<!--[\s\S]?%cayo\.\w+%[\s\S]*?(-->)/g, '')
-        // Inject markup in the cayo placeholders
+        // Inject markup in the new template cayo placeholders
         .replace(/<template cayo="title">[\s\S]*?<\/template>/g, () => !head.includes('<title>') ? title() : '')
         .replace(/<template cayo="head">[\s\S]*?<\/template>/g, () => head)
         .replace(/<template cayo="body">[\s\S]*?<\/template>/g, () => html)
         .replace(/<template cayo="css">[\s\S]*?<\/template>/g, () => cssElements)
-        // Vite needs the entry file in this format
-        .replace(/<template cayo="script">[\s\S]*?<\/template>/g, () => `<script type="module" src="./index.js"></script>`), 
+        .replace(/<template cayo="script">[\s\S]*?<\/template>/g, () => `<script type="module" src="./index.js"></script>`)
+        // Support deprecated %cayo.*% syntax for backward compatibility
+        .replace(/%cayo\.title%/g, () => !head.includes('<title>') ? title() : '')
+        .replace(/%cayo\.head%/g, () => head)
+        .replace(/%cayo\.body%/g, () => html)
+        .replace(/%cayo\.css%/g, () => cssElements)
+        .replace(/%cayo\.script%/g, () => `<script type="module" src="./index.js"></script>`), 
       css,
     }
   }

--- a/lib/core/render/renderer.js
+++ b/lib/core/render/renderer.js
@@ -40,12 +40,12 @@ export class Renderer {
         // Strip placeholders wrapped in HTML comments
         .replace(/<!--[\s\S]?%cayo\.\w+%[\s\S]*?(-->)/g, '')
         // Inject markup in the cayo placeholders
-        .replace('%cayo.title%', () => !head.includes('<title>') ? title() : '')
-        .replace('%cayo.head%', () => head)
-        .replace('%cayo.body%', () => html)
-        .replace('%cayo.css%', () => cssElements)
+        .replace(/<template cayo="title">[\s\S]*?<\/template>/g, () => !head.includes('<title>') ? title() : '')
+        .replace(/<template cayo="head">[\s\S]*?<\/template>/g, () => head)
+        .replace(/<template cayo="body">[\s\S]*?<\/template>/g, () => html)
+        .replace(/<template cayo="css">[\s\S]*?<\/template>/g, () => cssElements)
         // Vite needs the entry file in this format
-        .replace('%cayo.script%', () => `<script type="module" src="./index.js"></script>`), 
+        .replace(/<template cayo="script">[\s\S]*?<\/template>/g, () => `<script type="module" src="./index.js"></script>`), 
       css,
     }
   }

--- a/lib/core/render/renderer.js
+++ b/lib/core/render/renderer.js
@@ -58,22 +58,30 @@ export class Renderer {
       );
     }
 
+    const finalHtml = this.template.html
+      // Strip placeholders wrapped in HTML comments
+      .replace(/<!--[\s\S]?%cayo\.\w+%[\s\S]*?(-->)/g, '')
+      // Inject markup in the new template cayo placeholders (template elements)
+      .replace(/<template cayo="title">[\s\S]*?<\/template>/g, () => !head.includes('<title>') ? title() : '')
+      .replace(/<template cayo="head">[\s\S]*?<\/template>/g, () => head)
+      .replace(/<template cayo="body">[\s\S]*?<\/template>/g, () => html)
+      .replace(/<template cayo="css">[\s\S]*?<\/template>/g, () => cssElements)
+      .replace(/<template cayo="script">[\s\S]*?<\/template>/g, () => `<script type="module" src="./index.js"></script>`)
+      // Inject markup in HTML comment placeholders (fallback for when Svelte removes template elements)
+      .replace(/<!--\s*\[cayo-css\]\s*-->/g, () => cssElements)
+      .replace(/<!--\s*\[cayo-head\]\s*-->/g, () => head)
+      .replace(/<!--\s*\[cayo-body\]\s*-->/g, () => html)
+      .replace(/<!--\s*\[cayo-title\]\s*-->/g, () => !head.includes('<title>') ? title() : '')
+      .replace(/<!--\s*\[cayo-script\]\s*-->/g, () => `<script type="module" src="./index.js"></script>`)
+      // Support deprecated %cayo.*% syntax for backward compatibility
+      .replace(/%cayo\.title%/g, () => !head.includes('<title>') ? title() : '')
+      .replace(/%cayo\.head%/g, () => head)
+      .replace(/%cayo\.body%/g, () => html)
+      .replace(/%cayo\.css%/g, () => cssElements)
+      .replace(/%cayo\.script%/g, () => `<script type="module" src="./index.js"></script>`);
+
     return {
-      html: this.template.html
-        // Strip placeholders wrapped in HTML comments
-        .replace(/<!--[\s\S]?%cayo\.\w+%[\s\S]*?(-->)/g, '')
-        // Inject markup in the new template cayo placeholders
-        .replace(/<template cayo="title">[\s\S]*?<\/template>/g, () => !head.includes('<title>') ? title() : '')
-        .replace(/<template cayo="head">[\s\S]*?<\/template>/g, () => head)
-        .replace(/<template cayo="body">[\s\S]*?<\/template>/g, () => html)
-        .replace(/<template cayo="css">[\s\S]*?<\/template>/g, () => cssElements)
-        .replace(/<template cayo="script">[\s\S]*?<\/template>/g, () => `<script type="module" src="./index.js"></script>`)
-        // Support deprecated %cayo.*% syntax for backward compatibility
-        .replace(/%cayo\.title%/g, () => !head.includes('<title>') ? title() : '')
-        .replace(/%cayo\.head%/g, () => head)
-        .replace(/%cayo\.body%/g, () => html)
-        .replace(/%cayo\.css%/g, () => cssElements)
-        .replace(/%cayo\.script%/g, () => `<script type="module" src="./index.js"></script>`), 
+      html: finalHtml, 
       css,
     }
   }

--- a/lib/core/render/renderer.js
+++ b/lib/core/render/renderer.js
@@ -61,13 +61,7 @@ export class Renderer {
     const finalHtml = this.template.html
       // Strip placeholders wrapped in HTML comments
       .replace(/<!--[\s\S]?%cayo\.\w+%[\s\S]*?(-->)/g, '')
-      // Inject markup in the new template cayo placeholders (template elements)
-      .replace(/<template cayo="title">[\s\S]*?<\/template>/g, () => !head.includes('<title>') ? title() : '')
-      .replace(/<template cayo="head">[\s\S]*?<\/template>/g, () => head)
-      .replace(/<template cayo="body">[\s\S]*?<\/template>/g, () => html)
-      .replace(/<template cayo="css">[\s\S]*?<\/template>/g, () => cssElements)
-      .replace(/<template cayo="script">[\s\S]*?<\/template>/g, () => `<script type="module" src="./index.js"></script>`)
-      // Inject markup in HTML comment placeholders (fallback for when Svelte removes template elements)
+      // Inject markup in HTML comment placeholders
       .replace(/<!--\s*\[cayo-css\]\s*-->/g, () => cssElements)
       .replace(/<!--\s*\[cayo-head\]\s*-->/g, () => head)
       .replace(/<!--\s*\[cayo-body\]\s*-->/g, () => html)

--- a/lib/core/render/renderer.js
+++ b/lib/core/render/renderer.js
@@ -39,10 +39,21 @@ export class Renderer {
     //       A: In case there's dollar signs in that there string
     // https://stackoverflow.com/questions/9423722/string-replace-weird-behavior-when-using-dollar-sign-as-replacement
     // Check for deprecated %cayo.*% syntax and log deprecation warnings
-    const deprecatedPlaceholders = this.template.html.match(/%cayo\.[a-zA-Z]+%/g);
-    if (deprecatedPlaceholders) {
+    // Use a more specific regex and avoid overlapping matches
+    const deprecatedPlaceholders = [];
+    const regex = /%cayo\.[a-zA-Z]+%/g;
+    let match;
+    while ((match = regex.exec(this.template.html)) !== null) {
+      deprecatedPlaceholders.push(match[0]);
+    }
+    
+    if (deprecatedPlaceholders.length > 0 && !this._deprecationWarningLogged) {
+      this._deprecationWarningLogged = true;
+      const uniquePlaceholders = [...new Set(deprecatedPlaceholders)];
+
+      
       logger.log.info(
-        chalk.yellow.bold('Deprecation Warning') + chalk.yellow(': Found deprecated %cayo.*% placeholder syntax. Please migrate to <template cayo="..."> syntax. The old syntax will continue to work but may break in future Svelte versions.'),
+        chalk.yellow.bold('Deprecation Warning') + chalk.yellow(` [Page: ${page.name}]: Found deprecated placeholder syntax: ${uniquePlaceholders.join(', ')}. Please migrate to <template cayo="..."> syntax. \nMore info: https://github.com/matthew-ia/cayo#template-placeholder-migration`),
         { timestamp: true, clear: false }
       );
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cayo",
-  "version": "1.3.6",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cayo",
-      "version": "1.3.6",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-commonjs": "^29.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cayo",
-  "version": "1.3.6",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "start": "node cayo dev --projectRoot test",

--- a/template/src/__template.svelte
+++ b/template/src/__template.svelte
@@ -3,12 +3,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🏝</text></svg>">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    %cayo.title%
-    %cayo.css%    
-    %cayo.head%
+    <template cayo="title"></template>
+    <template cayo="css"></template>    
+    <template cayo="head"></template>
   </head>
   <body>
-    %cayo.body%
-    %cayo.script%
+    <template cayo="body"></template>
+    <template cayo="script"></template>
   </body>
 </html>


### PR DESCRIPTION
This is sort of a workaround because later versions of svelte / svelte-preprocess throw a compilation error with unsupported text nodes inside of the <head> element:

> Cause: Error: Could not compile template: '/Users/malicea/kit-2.1/test-5/src/__template.svelte'
> Rollup Error: PLUGIN_ERROR
> svelte (Error code: node_invalid_placement)

> Source: /Users/malicea/kit-2.1/test-5/src/__template.svelte
16:       <link href="https://res.cloudinary.com/petermillar/raw/upload/v1765288890/gfont.css" rel="stylesheet">
17:     {/if}
18:     <title>{process.env.KIT_TITLE} &ndash; {process.env.KIT_SITE} &ndash; {process.env.KIT_BASE}</title>
      ^
19:     %cayo.css%
20:     %cayo.head%
>
> Cause: node_invalid_placement: `<#text>` cannot be a child of `<head>`. `<head>` only allows these children: `<base>`, `<basefont>`, `<bgsound>`, `<link>`, `<meta>`, `<title>`, `<noscript>`, `<noframes>`, `<style>`, `<script>`, `<template>`. The browser will 'repair' the HTML (by moving, removing, or inserting elements) which breaks Svelte's assumptions about the structure of your components.
https://svelte.dev/e/node_invalid_placement

--- 

Conversion guide:

In your `__template.svelte`:

```svelte
<!-- Old -->
%cayo.body

<!-- New -->
<!-- [cayo-body] -->
```